### PR TITLE
for logged out case studies, cards obj can be empty while pagination

### DIFF
--- a/src/bundles/Search/components/Catalogue/Catalogue.js
+++ b/src/bundles/Search/components/Catalogue/Catalogue.js
@@ -164,7 +164,7 @@ export class Catalogue extends React.Component {
                     </div>
                     <hr/>
                   </article>
-                  {isEmpty(cards) ? (
+                  {(isEmpty(cards) && pagination.casestudies.total === 0) ? (
                     <article styleName={search.querying ? 'fadeOut' : 'fadeIn'}>
                       <h2>No exact matches</h2>
                       <p>Try tweaking your search criteria for more results or <Link to="/" onClick={(e) => {


### PR DESCRIPTION
obj has search results number > 0 which broke the messaging