### PR TITLE
Use old buildpack for node for compat with prod

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 command:  ./scripts/cf_run_app.sh
-buildpack: nodejs_buildpack
+# TODO: once prod is on new envs, switch back to supported buildpack
+buildpack: legacy_marketplace_nodejs_buildpack
 memory: 256M
 disk_quota: 1G
 instances: 1


### PR DESCRIPTION
I've uploaded buildpack v1.6.6 to `y-cld` - same as what is currently on `z-cld`.

Let's use that for now so that prod and staging can both use v8.2.1.

Let's update to a newer version once we're off the legacy prod env.