### PR TITLE
Remove /orams route

### DIFF
--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -11,6 +11,5 @@ routes:
 - route: dm-frontend.apps.b.cld.gov.au
 - route: marketplace.service.gov.au/bundle
 - route: marketplace.service.gov.au/2
-- route: marketplace.service.gov.au/orams
 applications:
 - name: dm-frontend

--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -11,5 +11,6 @@ routes:
 - route: dm-frontend.apps.b.cld.gov.au
 - route: marketplace.service.gov.au/bundle
 - route: marketplace.service.gov.au/2
+- route: marketplace.service.gov.au/orams
 applications:
 - name: dm-frontend

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,6 +11,5 @@ routes:
 - route: dm-dev-frontend.apps.y.cld.gov.au
 - route: dm-dev.apps.y.cld.gov.au/bundle
 - route: dm-dev.apps.y.cld.gov.au/2
-- route: dm-dev.apps.y.cld.gov.au/orams
 applications:
 - name: dm-dev-frontend

--- a/server/render.js
+++ b/server/render.js
@@ -56,7 +56,7 @@ app.post('/render', render);
 app.set('view engine', 'ejs');
 
 app.get('/orams*', function(req, res) {
-  res.render('orams');
+  res.redirect('https://orams.service.gov.au');
 })
 
 app.get('/2/insights*', function(req, res) {


### PR DESCRIPTION
removing bound route to /orams since standalone ORAMs will use this route.

DO NOT RELEASE until after 14th June 2018.  Stand-alone ORAMs scheduled to go live on 13th June COB.