### PR TITLE
Auth rep changes in seller application

### DIFF
--- a/src/bundles/SellerRegistration/components/Signup/__snapshots__/Signup.snaps.test.js.snap
+++ b/src/bundles/SellerRegistration/components/Signup/__snapshots__/Signup.snaps.test.js.snap
@@ -560,6 +560,93 @@ exports[`Signup renders empty Your Info form 1`] = `
           onReset={[Function]}
           onSubmit={[Function]}
         >
+          <h2>
+            Authorised representative
+          </h2>
+          <div
+            className="field"
+          >
+            <label
+              className="question-heading"
+              htmlFor="representative"
+            >
+              Name
+            </label>
+            <p
+              className="hint"
+              id="representative-hint"
+            >
+              This is the person authorised to enter into contracts on behalf of the business.
+            </p>
+            <input
+              className=""
+              disabled={false}
+              id="representative"
+              maxLength={undefined}
+              name="representative"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              pattern={undefined}
+              readOnly={undefined}
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            className="field"
+          >
+            <label
+              className="question-heading"
+              htmlFor="email"
+            >
+              Email
+            </label>
+            <input
+              className=""
+              disabled={false}
+              id="email"
+              maxLength={undefined}
+              name="email"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              pattern={undefined}
+              readOnly={undefined}
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            className="field"
+          >
+            <label
+              className="question-heading"
+              htmlFor="phone"
+            >
+              Phone
+            </label>
+            <input
+              className=""
+              disabled={false}
+              id="phone"
+              maxLength={undefined}
+              name="phone"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              pattern={undefined}
+              readOnly={undefined}
+              type="text"
+              value=""
+            />
+          </div>
+          <h2>
+            Business contact
+          </h2>
           <div
             className="field"
           >
@@ -567,7 +654,7 @@ exports[`Signup renders empty Your Info form 1`] = `
               className="question-heading"
               htmlFor="contact_name"
             >
-              Business contact name
+              Name
             </label>
             <p
               className="hint"
@@ -631,87 +718,6 @@ exports[`Signup renders empty Your Info form 1`] = `
               id="contact_phone"
               maxLength={undefined}
               name="contact_phone"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              pattern={undefined}
-              readOnly={undefined}
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            className="field"
-          >
-            <label
-              className="question-heading"
-              htmlFor="representative"
-            >
-              Authorised representative name
-            </label>
-            <p
-              className="hint"
-              id="representative-hint"
-            >
-              This is the person authorised to enter into contracts on behalf of the business. 
-            </p>
-            <input
-              className=""
-              disabled={false}
-              id="representative"
-              maxLength={undefined}
-              name="representative"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              pattern={undefined}
-              readOnly={undefined}
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            className="field"
-          >
-            <label
-              className="question-heading"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <input
-              className=""
-              disabled={false}
-              id="email"
-              maxLength={undefined}
-              name="email"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              pattern={undefined}
-              readOnly={undefined}
-              type="text"
-              value=""
-            />
-          </div>
-          <div
-            className="field"
-          >
-            <label
-              className="question-heading"
-              htmlFor="phone"
-            >
-              Phone
-            </label>
-            <input
-              className=""
-              disabled={false}
-              id="phone"
-              maxLength={undefined}
-              name="phone"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
@@ -1034,6 +1040,93 @@ exports[`Signup renders populated Your Info form 1`] = `
             type="hidden"
             value="abc"
           />
+          <h2>
+            Authorised representative
+          </h2>
+          <div
+            className="field"
+          >
+            <label
+              className="question-heading"
+              htmlFor="representative"
+            >
+              Name
+            </label>
+            <p
+              className="hint"
+              id="representative-hint"
+            >
+              This is the person authorised to enter into contracts on behalf of the business.
+            </p>
+            <input
+              className=""
+              disabled={false}
+              id="representative"
+              maxLength={undefined}
+              name="representative"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              pattern={undefined}
+              readOnly={undefined}
+              type="text"
+              value="Paul Acron"
+            />
+          </div>
+          <div
+            className="field"
+          >
+            <label
+              className="question-heading"
+              htmlFor="email"
+            >
+              Email
+            </label>
+            <input
+              className=""
+              disabled={false}
+              id="email"
+              maxLength={undefined}
+              name="email"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              pattern={undefined}
+              readOnly={undefined}
+              type="text"
+              value="email@domain.com"
+            />
+          </div>
+          <div
+            className="field"
+          >
+            <label
+              className="question-heading"
+              htmlFor="phone"
+            >
+              Phone
+            </label>
+            <input
+              className=""
+              disabled={false}
+              id="phone"
+              maxLength={undefined}
+              name="phone"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyPress={[Function]}
+              pattern={undefined}
+              readOnly={undefined}
+              type="text"
+              value="0292000000"
+            />
+          </div>
+          <h2>
+            Business contact
+          </h2>
           <div
             className="field"
           >
@@ -1041,7 +1134,7 @@ exports[`Signup renders populated Your Info form 1`] = `
               className="question-heading"
               htmlFor="contact_name"
             >
-              Business contact name
+              Name
             </label>
             <p
               className="hint"
@@ -1113,87 +1206,6 @@ exports[`Signup renders populated Your Info form 1`] = `
               readOnly={undefined}
               type="text"
               value={undefined}
-            />
-          </div>
-          <div
-            className="field"
-          >
-            <label
-              className="question-heading"
-              htmlFor="representative"
-            >
-              Authorised representative name
-            </label>
-            <p
-              className="hint"
-              id="representative-hint"
-            >
-              This is the person authorised to enter into contracts on behalf of the business. 
-            </p>
-            <input
-              className=""
-              disabled={false}
-              id="representative"
-              maxLength={undefined}
-              name="representative"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              pattern={undefined}
-              readOnly={undefined}
-              type="text"
-              value="Paul Acron"
-            />
-          </div>
-          <div
-            className="field"
-          >
-            <label
-              className="question-heading"
-              htmlFor="email"
-            >
-              Email
-            </label>
-            <input
-              className=""
-              disabled={false}
-              id="email"
-              maxLength={undefined}
-              name="email"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              pattern={undefined}
-              readOnly={undefined}
-              type="text"
-              value="email@domain.com"
-            />
-          </div>
-          <div
-            className="field"
-          >
-            <label
-              className="question-heading"
-              htmlFor="phone"
-            >
-              Phone
-            </label>
-            <input
-              className=""
-              disabled={false}
-              id="phone"
-              maxLength={undefined}
-              name="phone"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              pattern={undefined}
-              readOnly={undefined}
-              type="text"
-              value="0292000000"
             />
           </div>
           <input

--- a/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
+++ b/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
@@ -81,7 +81,6 @@ class YourInfoForm extends BaseForm {
                   }}
               />
 
-
               <Textfield
                   model={`${model}.email`}
                   name="email"
@@ -137,7 +136,6 @@ class YourInfoForm extends BaseForm {
                   }}
                   default={userEmail}
               />
-
 
               <Textfield
                   model={`${model}.contact_phone`}

--- a/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
+++ b/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
@@ -47,7 +47,6 @@ class YourInfoForm extends BaseForm {
           <div className="calloutMistake">
             <b> Avoid common mistakes </b>
             <ul>
-
               <li><b>Contact names</b> - use full names.</li>
               <li><b>Email and phone numbers</b> - Check the format and details are correct.</li>
             </ul>

--- a/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
+++ b/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
@@ -66,12 +66,56 @@ class YourInfoForm extends BaseForm {
               <input type="hidden" name="csrf_token" id="csrf_token" value={csrf_token} />
             )}
 
+              <h2>Authorised representative</h2>
+
+              <Textfield
+                  model={`${model}.representative`}
+                  name="representative"
+                  id="representative"
+                  htmlFor="representative"
+                  label="Name"
+                  description="This is the person authorised to enter into contracts on behalf of the business."
+                  validators={{ required }}
+                  messages={{
+                      required: 'Authorised representative is required',
+                  }}
+              />
+
+
+              <Textfield
+                  model={`${model}.email`}
+                  name="email"
+                  id="email"
+                  htmlFor="email"
+                  label="Email"
+                  validators={{ required, validEmail }}
+                  messages={{
+                      required: 'Authorised representative\'s email is required',
+                      validEmail: 'Authorised representative\'s email must be a valid email address',
+                  }}
+              />
+
+              <Textfield
+                  model={`${model}.phone`}
+                  name="phone"
+                  id="phone"
+                  htmlFor="phone"
+                  label="Phone"
+                  validators={{ required, validPhoneNumber }}
+                  messages={{
+                      required: 'Authorised representative\'s phone number is required',
+                      validPhoneNumber: 'Authorised representative\'s phone number must be a valid phone number',
+                  }}
+              />
+
+              <h2>Business contact</h2>
+
               <Textfield
                   model={`${model}.contact_name`}
                   name="contact_name"
                   id="contact_name"
                   htmlFor="contact_name"
-                  label="Business contact name"
+                  label="Name"
                   description="The contact listed on your seller profile page and the person who receives new opportunities by email."
                   validators={{ required }}
                   messages={{
@@ -105,49 +149,6 @@ class YourInfoForm extends BaseForm {
                   messages={{
                       required: 'Business contact phone is required',
                       validPhoneNumber: 'Business contact phone number must be a valid phone number',
-                  }}
-              />
-
-              <Textfield
-                  model={`${model}.representative`}
-                  name="representative"
-                  id="representative"
-                  htmlFor="representative"
-                  label="Authorised representative name"
-                  description={ isNumber(supplierCode)
-                    ? ["This is the person authorised to enter into contracts on behalf of the business. To update this please " ,<a href="/contact-us">contact us</a>, "."]
-                    : "This is the person authorised to enter into contracts on behalf of the business. "
-                  }
-                  validators={{ required }}
-                  messages={{
-                      required: 'Authorised representative is required',
-                  }}
-              />
-
-
-              <Textfield
-                  model={`${model}.email`}
-                  name="email"
-                  id="email"
-                  htmlFor="email"
-                  label="Email"
-                  validators={{ required, validEmail }}
-                  messages={{
-                      required: 'Authorised representative\'s email is required',
-                      validEmail: 'Authorised representative\'s email must be a valid email address',
-                  }}
-              />
-
-              <Textfield
-                  model={`${model}.phone`}
-                  name="phone"
-                  id="phone"
-                  htmlFor="phone"
-                  label="Phone"
-                  validators={{ required, validPhoneNumber }}
-                  messages={{
-                      required: 'Authorised representative\'s phone number is required',
-                      validPhoneNumber: 'Authorised representative\'s phone number must be a valid phone number',
                   }}
               />
 

--- a/src/bundles/SellerRegistration/components/YourInfoForm/__snapshots__/YourInfoForm.snaps.test.js.snap
+++ b/src/bundles/SellerRegistration/components/YourInfoForm/__snapshots__/YourInfoForm.snaps.test.js.snap
@@ -42,6 +42,93 @@ exports[`YourInfoForm renders 1`] = `
       onReset={[Function]}
       onSubmit={[Function]}
     >
+      <h2>
+        Authorised representative
+      </h2>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="representative"
+        >
+          Name
+        </label>
+        <p
+          className="hint"
+          id="representative-hint"
+        >
+          This is the person authorised to enter into contracts on behalf of the business.
+        </p>
+        <input
+          className=""
+          disabled={false}
+          id="representative"
+          maxLength={undefined}
+          name="representative"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="email"
+        >
+          Email
+        </label>
+        <input
+          className=""
+          disabled={false}
+          id="email"
+          maxLength={undefined}
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="phone"
+        >
+          Phone
+        </label>
+        <input
+          className=""
+          disabled={false}
+          id="phone"
+          maxLength={undefined}
+          name="phone"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <h2>
+        Business contact
+      </h2>
       <div
         className="field"
       >
@@ -49,7 +136,7 @@ exports[`YourInfoForm renders 1`] = `
           className="question-heading"
           htmlFor="contact_name"
         >
-          Business contact name
+          Name
         </label>
         <p
           className="hint"
@@ -113,87 +200,6 @@ exports[`YourInfoForm renders 1`] = `
           id="contact_phone"
           maxLength={undefined}
           name="contact_phone"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="representative"
-        >
-          Authorised representative name
-        </label>
-        <p
-          className="hint"
-          id="representative-hint"
-        >
-          This is the person authorised to enter into contracts on behalf of the business. 
-        </p>
-        <input
-          className=""
-          disabled={false}
-          id="representative"
-          maxLength={undefined}
-          name="representative"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="email"
-        >
-          Email
-        </label>
-        <input
-          className=""
-          disabled={false}
-          id="email"
-          maxLength={undefined}
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="phone"
-        >
-          Phone
-        </label>
-        <input
-          className=""
-          disabled={false}
-          id="phone"
-          maxLength={undefined}
-          name="phone"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -293,6 +299,93 @@ exports[`YourInfoForm renders with edit mode 1`] = `
         type="hidden"
         value="sometoken"
       />
+      <h2>
+        Authorised representative
+      </h2>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="representative"
+        >
+          Name
+        </label>
+        <p
+          className="hint"
+          id="representative-hint"
+        >
+          This is the person authorised to enter into contracts on behalf of the business.
+        </p>
+        <input
+          className=""
+          disabled={false}
+          id="representative"
+          maxLength={undefined}
+          name="representative"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="email"
+        >
+          Email
+        </label>
+        <input
+          className=""
+          disabled={false}
+          id="email"
+          maxLength={undefined}
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="phone"
+        >
+          Phone
+        </label>
+        <input
+          className=""
+          disabled={false}
+          id="phone"
+          maxLength={undefined}
+          name="phone"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <h2>
+        Business contact
+      </h2>
       <div
         className="field"
       >
@@ -300,7 +393,7 @@ exports[`YourInfoForm renders with edit mode 1`] = `
           className="question-heading"
           htmlFor="contact_name"
         >
-          Business contact name
+          Name
         </label>
         <p
           className="hint"
@@ -364,87 +457,6 @@ exports[`YourInfoForm renders with edit mode 1`] = `
           id="contact_phone"
           maxLength={undefined}
           name="contact_phone"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="representative"
-        >
-          Authorised representative name
-        </label>
-        <p
-          className="hint"
-          id="representative-hint"
-        >
-          This is the person authorised to enter into contracts on behalf of the business. 
-        </p>
-        <input
-          className=""
-          disabled={false}
-          id="representative"
-          maxLength={undefined}
-          name="representative"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="email"
-        >
-          Email
-        </label>
-        <input
-          className=""
-          disabled={false}
-          id="email"
-          maxLength={undefined}
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="phone"
-        >
-          Phone
-        </label>
-        <input
-          className=""
-          disabled={false}
-          id="phone"
-          maxLength={undefined}
-          name="phone"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -544,6 +556,93 @@ exports[`YourInfoForm renders with form_options 1`] = `
         type="hidden"
         value="sometoken"
       />
+      <h2>
+        Authorised representative
+      </h2>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="representative"
+        >
+          Name
+        </label>
+        <p
+          className="hint"
+          id="representative-hint"
+        >
+          This is the person authorised to enter into contracts on behalf of the business.
+        </p>
+        <input
+          className=""
+          disabled={false}
+          id="representative"
+          maxLength={undefined}
+          name="representative"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="email"
+        >
+          Email
+        </label>
+        <input
+          className=""
+          disabled={false}
+          id="email"
+          maxLength={undefined}
+          name="email"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <div
+        className="field"
+      >
+        <label
+          className="question-heading"
+          htmlFor="phone"
+        >
+          Phone
+        </label>
+        <input
+          className=""
+          disabled={false}
+          id="phone"
+          maxLength={undefined}
+          name="phone"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyPress={[Function]}
+          pattern={undefined}
+          readOnly={undefined}
+          type="text"
+          value={undefined}
+        />
+      </div>
+      <h2>
+        Business contact
+      </h2>
       <div
         className="field"
       >
@@ -551,7 +650,7 @@ exports[`YourInfoForm renders with form_options 1`] = `
           className="question-heading"
           htmlFor="contact_name"
         >
-          Business contact name
+          Name
         </label>
         <p
           className="hint"
@@ -615,87 +714,6 @@ exports[`YourInfoForm renders with form_options 1`] = `
           id="contact_phone"
           maxLength={undefined}
           name="contact_phone"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="representative"
-        >
-          Authorised representative name
-        </label>
-        <p
-          className="hint"
-          id="representative-hint"
-        >
-          This is the person authorised to enter into contracts on behalf of the business. 
-        </p>
-        <input
-          className=""
-          disabled={false}
-          id="representative"
-          maxLength={undefined}
-          name="representative"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="email"
-        >
-          Email
-        </label>
-        <input
-          className=""
-          disabled={false}
-          id="email"
-          maxLength={undefined}
-          name="email"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          pattern={undefined}
-          readOnly={undefined}
-          type="text"
-          value={undefined}
-        />
-      </div>
-      <div
-        className="field"
-      >
-        <label
-          className="question-heading"
-          htmlFor="phone"
-        >
-          Phone
-        </label>
-        <input
-          className=""
-          disabled={false}
-          id="phone"
-          maxLength={undefined}
-          name="phone"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
This PR affects the seller application contact page by:

* Removing the wording that suggests users need to contact us to change who the auth rep is.
* Add H2 headers to separate the Auth rep and Business contact sections
* Move the auth rep fields above business contact fields