### PR TITLE
[Seller Registration] Add descriptions to phone fields

### DIFF
--- a/src/bundles/CaseStudy/components/CaseStudyForm/CaseStudyForm.js
+++ b/src/bundles/CaseStudy/components/CaseStudyForm/CaseStudyForm.js
@@ -271,6 +271,7 @@ class CaseStudyForm extends BaseForm {
                 id="refereeEmail"
                 htmlFor="refereeEmail"
                 label="Referee's phone number"
+                description="Please include the area code for landlines."
                 validators={{ required, validPhoneNumber }}
                 messages={{
                   required: 'Please provide a referee phone number.',

--- a/src/bundles/CaseStudy/components/CaseStudyForm/__snapshots__/CaseStudyForm.snaps.test.js.snap
+++ b/src/bundles/CaseStudy/components/CaseStudyForm/__snapshots__/CaseStudyForm.snaps.test.js.snap
@@ -554,6 +554,12 @@ exports[`CaseStudyForm renders 1`] = `
         >
           Referee's phone number
         </label>
+        <p
+          className="hint"
+          id="refereeEmail-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -1152,6 +1158,12 @@ exports[`CaseStudyForm renders empty in edit mode 1`] = `
         >
           Referee's phone number
         </label>
+        <p
+          className="hint"
+          id="refereeEmail-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -1968,6 +1980,12 @@ exports[`CaseStudyForm renders with errors 1`] = `
         >
           Referee's phone number
         </label>
+        <p
+          className="hint"
+          id="refereeEmail-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <a
           className="validation-message"
           href="#refereeEmail"
@@ -2598,6 +2616,12 @@ exports[`CaseStudyForm renders with form_options 1`] = `
         >
           Referee's phone number
         </label>
+        <p
+          className="hint"
+          id="refereeEmail-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -3196,6 +3220,12 @@ exports[`CaseStudyForm renders with populated fields 1`] = `
         >
           Referee's phone number
         </label>
+        <p
+          className="hint"
+          id="refereeEmail-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}

--- a/src/bundles/SellerRegistration/components/Signup/__snapshots__/Signup.snaps.test.js.snap
+++ b/src/bundles/SellerRegistration/components/Signup/__snapshots__/Signup.snaps.test.js.snap
@@ -628,6 +628,12 @@ exports[`Signup renders empty Your Info form 1`] = `
             >
               Phone
             </label>
+            <p
+              className="hint"
+              id="phone-hint"
+            >
+              Please include the area code for landlines.
+            </p>
             <input
               className=""
               disabled={false}
@@ -712,6 +718,12 @@ exports[`Signup renders empty Your Info form 1`] = `
             >
               Phone
             </label>
+            <p
+              className="hint"
+              id="contact_phone-hint"
+            >
+              Please include the area code for landlines.
+            </p>
             <input
               className=""
               disabled={false}
@@ -1108,6 +1120,12 @@ exports[`Signup renders populated Your Info form 1`] = `
             >
               Phone
             </label>
+            <p
+              className="hint"
+              id="phone-hint"
+            >
+              Please include the area code for landlines.
+            </p>
             <input
               className=""
               disabled={false}
@@ -1192,6 +1210,12 @@ exports[`Signup renders populated Your Info form 1`] = `
             >
               Phone
             </label>
+            <p
+              className="hint"
+              id="contact_phone-hint"
+            >
+              Please include the area code for landlines.
+            </p>
             <input
               className=""
               disabled={false}

--- a/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
+++ b/src/bundles/SellerRegistration/components/YourInfoForm/YourInfoForm.js
@@ -99,6 +99,7 @@ class YourInfoForm extends BaseForm {
                   id="phone"
                   htmlFor="phone"
                   label="Phone"
+                  description="Please include the area code for landlines."
                   validators={{ required, validPhoneNumber }}
                   messages={{
                       required: 'Authorised representative\'s phone number is required',
@@ -142,6 +143,7 @@ class YourInfoForm extends BaseForm {
                   id="contact_phone"
                   htmlFor="contact_phone"
                   label="Phone"
+                  description="Please include the area code for landlines."
                   validators={{ required, validPhoneNumber }}
                   messages={{
                       required: 'Business contact phone is required',

--- a/src/bundles/SellerRegistration/components/YourInfoForm/__snapshots__/YourInfoForm.snaps.test.js.snap
+++ b/src/bundles/SellerRegistration/components/YourInfoForm/__snapshots__/YourInfoForm.snaps.test.js.snap
@@ -110,6 +110,12 @@ exports[`YourInfoForm renders 1`] = `
         >
           Phone
         </label>
+        <p
+          className="hint"
+          id="phone-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -194,6 +200,12 @@ exports[`YourInfoForm renders 1`] = `
         >
           Phone
         </label>
+        <p
+          className="hint"
+          id="contact_phone-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -367,6 +379,12 @@ exports[`YourInfoForm renders with edit mode 1`] = `
         >
           Phone
         </label>
+        <p
+          className="hint"
+          id="phone-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -451,6 +469,12 @@ exports[`YourInfoForm renders with edit mode 1`] = `
         >
           Phone
         </label>
+        <p
+          className="hint"
+          id="contact_phone-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -624,6 +648,12 @@ exports[`YourInfoForm renders with form_options 1`] = `
         >
           Phone
         </label>
+        <p
+          className="hint"
+          id="phone-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}
@@ -708,6 +738,12 @@ exports[`YourInfoForm renders with form_options 1`] = `
         >
           Phone
         </label>
+        <p
+          className="hint"
+          id="contact_phone-hint"
+        >
+          Please include the area code for landlines.
+        </p>
         <input
           className=""
           disabled={false}


### PR DESCRIPTION
This adds the following description to phone number fields in the seller registration / application flow: 
> Please include the area code for landlines

Addresses MAR-1800