### PR TITLE
[Case Study] Update brief response template links

### DIFF
--- a/src/bundles/CaseStudy/components/SubmitConfirmation/SubmitConfirmation.js
+++ b/src/bundles/CaseStudy/components/SubmitConfirmation/SubmitConfirmation.js
@@ -9,6 +9,7 @@ class SubmitConfirmation extends React.Component {
 
     render() {
         const {
+            briefLot,
             domain,
             closingDate,
             previewUrl,
@@ -35,14 +36,18 @@ class SubmitConfirmation extends React.Component {
                             <b> {format(new Date(closingDate), 'Do MMMM YYYY')}</b>.
                         </p>
 
-                        <p>
-                            While you wait you can prepare your response
-                            using our Google sheets template.
-                        </p>
+                        <p>While you wait, you can prepare your response by downloading the template.</p>
 
                         <p styleName="footer-link">
-                            <a href={previewUrl} download>
-                                Download brief response template</a>
+                            {briefLot == 'training' ? (
+                                <a class="au-btn" href="/static/media/documents/Training_opportunities_questions_for_sellers.docx" download>
+                                    Download response template (DOCX)
+                                </a>
+                            ) : (
+                                <a class="au-btn" href={previewUrl} download>
+                                    Download response template (XLSX)
+                                </a>
+                            )}
                         </p>
                     </span>
                 )}


### PR DESCRIPTION
This adds a link to the training template sellers can download while their assessment is being processed.

Addresses MAR-2140