### PR TITLE
[Views] Remove references to accordion and animate scripts

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -62,7 +62,5 @@
 </noscript>
 <div id="root"></div>
 <script crossorigin src="/bundle/marketplace.js"></script>
-<script src="/bundle/pancake/js/accordion.js"></script>
-<script src="/bundle/pancake/js/animate.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull request prevents the `animate.js` and `accordion.js` scripts from loading on every page.