### PR TITLE
[Seller application] Fix workers compensation insurance checkbox

### DIFF
--- a/src/bundles/Collaborate/components/ProjectForm/ProjectForm.js
+++ b/src/bundles/Collaborate/components/ProjectForm/ProjectForm.js
@@ -403,14 +403,18 @@ class ProjectForm extends BaseForm {
                                     required: 'Please acknowledge the contact point.'
                                 }}
                             />
-                            <Control.checkbox
-                                model={`${model}.contact_agreed`}
-                                id="contactAgreed"
-                                name="contact_agreed"
-                                validators={{required}}
-                            />
-                            <label htmlFor="contactAgreed">I confirm this person gives permission to be contacted and
-                                approve the use of this information being made public on the Digital Marketplace.
+                            <label className="au-control-input" htmlFor="contactAgreed">
+                                <Control.checkbox
+                                    className="au-control-input__input"
+                                    model={`${model}.contact_agreed`}
+                                    id="contactAgreed"
+                                    name="contact_agreed"
+                                    validators={{required}}
+                                />
+                                <span className="au-control-input__text">
+                                    I confirm this person gives permission to be contacted and
+                                    approve the use of this information being made public on the Digital Marketplace.
+                                </span>
                             </label>
                         </div>
 

--- a/src/bundles/Collaborate/components/ProjectForm/__snapshots__/ProjectForm.snaps.test.js.snap
+++ b/src/bundles/Collaborate/components/ProjectForm/__snapshots__/ProjectForm.snaps.test.js.snap
@@ -748,21 +748,27 @@ exports[`ProjectForm renders 1`] = `
         />
       </div>
       <div>
-        <input
-          checked={false}
-          disabled={false}
-          id="contactAgreed"
-          name="contact_agreed"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          type="checkbox"
-        />
         <label
+          className="au-control-input"
           htmlFor="contactAgreed"
         >
-          I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          <input
+            checked={false}
+            className="au-control-input__input"
+            disabled={false}
+            id="contactAgreed"
+            name="contact_agreed"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="checkbox"
+          />
+          <span
+            className="au-control-input__text"
+          >
+            I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          </span>
         </label>
       </div>
       <input
@@ -1522,21 +1528,27 @@ exports[`ProjectForm renders empty in edit mode 1`] = `
         />
       </div>
       <div>
-        <input
-          checked={false}
-          disabled={false}
-          id="contactAgreed"
-          name="contact_agreed"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          type="checkbox"
-        />
         <label
+          className="au-control-input"
           htmlFor="contactAgreed"
         >
-          I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          <input
+            checked={false}
+            className="au-control-input__input"
+            disabled={false}
+            id="contactAgreed"
+            name="contact_agreed"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="checkbox"
+          />
+          <span
+            className="au-control-input__text"
+          >
+            I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          </span>
         </label>
       </div>
       <input
@@ -2535,21 +2547,27 @@ exports[`ProjectForm renders with errors 1`] = `
             Please acknowledge the contact point.
           </span>
         </a>
-        <input
-          checked={false}
-          disabled={false}
-          id="contactAgreed"
-          name="contact_agreed"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          type="checkbox"
-        />
         <label
+          className="au-control-input"
           htmlFor="contactAgreed"
         >
-          I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          <input
+            checked={false}
+            className="au-control-input__input"
+            disabled={false}
+            id="contactAgreed"
+            name="contact_agreed"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="checkbox"
+          />
+          <span
+            className="au-control-input__text"
+          >
+            I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          </span>
         </label>
       </div>
       <input
@@ -3315,21 +3333,27 @@ exports[`ProjectForm renders with form_options 1`] = `
         />
       </div>
       <div>
-        <input
-          checked={false}
-          disabled={false}
-          id="contactAgreed"
-          name="contact_agreed"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          type="checkbox"
-        />
         <label
+          className="au-control-input"
           htmlFor="contactAgreed"
         >
-          I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          <input
+            checked={false}
+            className="au-control-input__input"
+            disabled={false}
+            id="contactAgreed"
+            name="contact_agreed"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="checkbox"
+          />
+          <span
+            className="au-control-input__text"
+          >
+            I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          </span>
         </label>
       </div>
       <input
@@ -4089,21 +4113,27 @@ exports[`ProjectForm renders with populated fields 1`] = `
         />
       </div>
       <div>
-        <input
-          checked={false}
-          disabled={false}
-          id="contactAgreed"
-          name="contact_agreed"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyPress={[Function]}
-          type="checkbox"
-        />
         <label
+          className="au-control-input"
           htmlFor="contactAgreed"
         >
-          I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          <input
+            checked={false}
+            className="au-control-input__input"
+            disabled={false}
+            id="contactAgreed"
+            name="contact_agreed"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyPress={[Function]}
+            type="checkbox"
+          />
+          <span
+            className="au-control-input__text"
+          >
+            I confirm this person gives permission to be contacted and approve the use of this information being made public on the Digital Marketplace.
+          </span>
         </label>
       </div>
       <input

--- a/src/shared/SellerProfile/PrivateInfo.js
+++ b/src/shared/SellerProfile/PrivateInfo.js
@@ -84,14 +84,15 @@ const PrivateInfo = (props) => {
                     </thead>
                     <tbody>
                     {Object.keys(documents).map((key, val) => {
-                        const {filename, expiry, application_id} = documents[key];
+                        const {filename, expiry, application_id, noWorkersCompensation} = documents[key];
                         const url = application_id ? `/admin/application/${application_id}/documents/` : documentsUrl
                         return (
                             <tr key={val}>
                                 <td>
-                                    <a href={`${url}${filename}`}>
-                                        {documentTitle[key]}
-                                    </a>
+                                    {key == 'workers' && noWorkersCompensation
+                                        ? documentTitle[key]
+                                        : <a href={`${url}${filename}`}>{documentTitle[key]}</a>
+                                    }
                                 </td>
                                 <td>
                                     {expiry && format(new Date(expiry), 'DD/MM/YYYY')}

--- a/src/shared/SellerProfile/PrivateInfo.js
+++ b/src/shared/SellerProfile/PrivateInfo.js
@@ -102,6 +102,11 @@ const PrivateInfo = (props) => {
                     })}
                     </tbody>
                 </table>
+                {documents.workers.noWorkersCompensation && 
+                    <p>
+                        <b>Workers compensation insurance not held by this seller</b>
+                    </p>
+                }
             </Row>
             <Row title="Recruiter Info" show={!isEmpty(recruiter_info)}>
               {Object.keys(recruiter_info).map((key, i) => {

--- a/src/shared/form/CheckboxDetailsField.js
+++ b/src/shared/form/CheckboxDetailsField.js
@@ -32,9 +32,9 @@ class CheckboxDetailsField extends React.Component {
     /* eslint-disable jsx-a11y/label-has-for */
 
     return (
-      <label className="uikit-control-input" htmlFor={id}>
+      <label className="au-control-input" htmlFor={id}>
         <Control.checkbox
-          className="uikit-control-input__input"
+          className="au-control-input__input"
           onClick={this.onToggle.bind(this)}
           id={id}
           name={name}
@@ -43,7 +43,7 @@ class CheckboxDetailsField extends React.Component {
           validators={validators}
           disabled={disabled}
         />
-        <span className="uikit-control-input__text">
+        <span className="au-control-input__text">
           {label}
         </span>
         {/*<StatefulError model={model} messages={messages} id={id} />*/}


### PR DESCRIPTION
This pull request contains the following changes:
- Adds Design System classes to checkboxes that did not have them or needed their focus improved.  Others will need to be updated when pages are rebuilt
- Renders a link to the seller's workers compensation insurance document only if they uploaded one
- Adds a message to indicate no workers compensation insurance is held by the seller

Addresses MAR-2300