### PR TITLE
[Seller profile] Add checks before displaying workers compensation message

### DIFF
--- a/src/shared/SellerProfile/PrivateInfo.js
+++ b/src/shared/SellerProfile/PrivateInfo.js
@@ -102,7 +102,7 @@ const PrivateInfo = (props) => {
                     })}
                     </tbody>
                 </table>
-                {documents.workers.noWorkersCompensation && 
+                {documents && documents.workers && documents.workers.noWorkersCompensation && 
                     <p>
                         <b>Workers compensation insurance not held by this seller</b>
                     </p>


### PR DESCRIPTION
These checks are being added after the following error was captured by Rollbar (seller application that had no documents).
> TypeError: Cannot read property 'noWorkersCompensation' of undefined

Addresses MAR-2353