### PR TITLE
Fix the header signup and login button :focus states

### DIFF
--- a/public/custom.css
+++ b/public/custom.css
@@ -147,6 +147,15 @@ input[type="radio"].au-control-input__input:focus + .au-control-input__text:befo
 .au-body a.au-btn:focus,.au-body a.au-btn:hover {
   background-color: #135566;
 }
+header ul#main-navigation a.au-btn:focus,header ul#main-navigation a.au-btn:hover {
+  background-color: #fff;
+  border-color: #fff;
+}
+header ul#main-navigation a.au-btn--secondary:focus,header ul#main-navigation a.au-btn--secondary:hover {
+  background-color: inherit;
+  border-color: #fff;
+  color: #fff;
+}
 .au-body a.au-btn--tertiary:focus, .au-body a.au-btn--tertiary:hover {
   background-color: #e8f2f4;
 }


### PR DESCRIPTION
Fix the header signup and login button :focus states so they are the same as :hover. Currently, the :focus state produces the following:

![home-focus-issue](https://user-images.githubusercontent.com/1152676/45727003-2d8eed00-bc05-11e8-9320-6c1a3c09418d.png)
