### PR TITLE
Fix opportunities test

### DIFF
--- a/apps/marketplace/components/Opportunities/Opportunities.test.js
+++ b/apps/marketplace/components/Opportunities/Opportunities.test.js
@@ -63,10 +63,9 @@ test('component mounts with opportunities and displays the appropriate informati
       'Exploration of commercial datasets to answer questions about household and SME energy use and costs'
     )
   ).toBeTruthy()
+
   expect(component.contains(1260)).toBeTruthy()
   expect(component.contains('8 (5 SME)')).toBeTruthy()
-  expect(component.contains('1w : 6d : 22h')).toBeTruthy()
-  expect(component.contains('3d : 23h : 59m')).toBeTruthy()
   expect(component.contains('0d : 2h : 59m')).toBeTruthy()
   expect(component.contains('Closed')).toBeTruthy()
   expect(component.contains('Sydney, Offsite')).toBeTruthy()

--- a/apps/marketplace/components/Opportunities/Opportunities.test.js
+++ b/apps/marketplace/components/Opportunities/Opportunities.test.js
@@ -63,7 +63,6 @@ test('component mounts with opportunities and displays the appropriate informati
       'Exploration of commercial datasets to answer questions about household and SME energy use and costs'
     )
   ).toBeTruthy()
-
   expect(component.contains(1260)).toBeTruthy()
   expect(component.contains('8 (5 SME)')).toBeTruthy()
   expect(component.contains('0d : 2h : 59m')).toBeTruthy()


### PR DESCRIPTION
Remove two problematic assertions that will fail when the current date and future dates span two different timezone configs (e.g. day light saving)