### PR TITLE
Adjust the accepted file extensions on ATM and RFX brief responses

### DIFF
--- a/apps/marketplace/components/Brief/BriefATMResponseForm.js
+++ b/apps/marketplace/components/Brief/BriefATMResponseForm.js
@@ -132,6 +132,7 @@ const BriefATMResponseForm = ({
                     requiredFile: 'You must upload your written proposal'
                   }}
                   uploading={uploading}
+                  accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx"
                 />
               )}
               <Textfield

--- a/apps/marketplace/components/Brief/BriefRFXResponseForm.js
+++ b/apps/marketplace/components/Brief/BriefRFXResponseForm.js
@@ -70,6 +70,7 @@ const BriefRFXResponseForm = ({
                           requiredFile: 'You must upload your written proposal'
                         }}
                         uploading={uploading}
+                        accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx"
                       />
                     )
                   } else if (evaluationType === 'Response template') {
@@ -91,6 +92,7 @@ const BriefRFXResponseForm = ({
                           requiredFile: 'You must upload your completed response template'
                         }}
                         uploading={uploading}
+                        accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx"
                       />
                     )
                   }


### PR DESCRIPTION
This PR will adjust the ATM and RFX brief response file input elements to accept the same file extensions as the file input elements in the ATM and RFX brief flows, to fix an issue where a buyer can upload a response template in a format a seller can't upload in their response.