### PR TITLE
Fix issue where null filename causes issues on opportunity pages

### DIFF
--- a/apps/marketplace/components/Opportunity/Opportunity.js
+++ b/apps/marketplace/components/Opportunity/Opportunity.js
@@ -60,7 +60,7 @@ const getClosingTime = brief => {
 
 const getTrimmedFilename = fileName => {
   let newFileName = fileName
-  if (fileName.length > 32) {
+  if (fileName && fileName.length > 32) {
     // build a limited version of the file name, taking out chars from the middle
     newFileName = `${fileName.substring(0, 14)}...${fileName.substring(fileName.length - 15)}`
   }


### PR DESCRIPTION
A yet unidentified issue results in a file attachment in a RFX (and possibly other flows) brief being stored as "null". This causes an uncaught exception when viewing the brief (which results in a blank white screen). This PR prevents null values from causing an issue.