### PR TITLE
Add a warning message to the case study stage in seller profile.

### DIFF
--- a/src/bundles/CaseStudy/components/DomainList/DomainList.js
+++ b/src/bundles/CaseStudy/components/DomainList/DomainList.js
@@ -131,6 +131,12 @@ class DomainList extends BaseForm {
       let header = (<header styleName="styles.content">
         <ValidationSummary form={form} applicationErrors={applicationErrors} filterFunc={(ae) => ae.step === 'case-study' && type === 'edit'} />
         <h1 className="au-display-xl" styleName="styles.content-heading" tabIndex="-1">{title}</h1>
+        <div class="au-body au-page-alerts au-page-alerts--warning">
+          <h3>Important change coming!</h3>
+          <p>We are making changes to the way you request assessment and approval for categories.</p>
+          <p>From X July 2019 instead of being assessed through case studies, you must prove your ability against individual criteria based on your previous work.</p>
+        </div>
+        <br />
         <p>
           Your case studies are important for more than meeting our <a href="/assessment-criteria" target="_blank" rel="external">assessment criteria</a>.<br/>
           They become part of your seller profile, so think of them as the beginning of your conversation
@@ -142,6 +148,12 @@ class DomainList extends BaseForm {
         header = (<header styleName="styles.content">
           <ValidationSummary form={form} applicationErrors={applicationErrors} filterFunc={(ae) => ae.step === 'case-study' && type === 'edit'} />
           <h1 className="au-display-xl" styleName="styles.content-heading" tabIndex="-1">{title}</h1>
+          <div class="au-body au-page-alerts au-page-alerts--warning">
+            <h3>Important change coming!</h3>
+            <p>We are making changes to the way you request assessment and approval for categories.</p>
+            <p>From X July 2019 instead of being assessed through case studies, you must prove your ability against individual criteria based on your previous work.</p>
+          </div>
+          <br />
           <p>Case studies are important for showing you meet our <a href="/assessment-criteria" target="_blank" rel="external">assessment criteria</a> for any new
             services you wish to offer.</p>
           <p> But they are also much more. Think of them as the beginning of a

--- a/src/bundles/CaseStudy/components/DomainList/DomainList.js
+++ b/src/bundles/CaseStudy/components/DomainList/DomainList.js
@@ -134,7 +134,7 @@ class DomainList extends BaseForm {
         <div class="au-body au-page-alerts au-page-alerts--warning">
           <h3>Important change coming!</h3>
           <p>We are making changes to the way you request assessment and approval for categories.</p>
-          <p>From X July 2019 instead of being assessed through case studies, you must prove your ability against individual criteria based on your previous work.</p>
+          <p>From 15 July 2019 instead of being assessed through case studies, you must prove your ability against individual criteria based on your previous work.</p>
         </div>
         <br />
         <p>
@@ -151,7 +151,7 @@ class DomainList extends BaseForm {
           <div class="au-body au-page-alerts au-page-alerts--warning">
             <h3>Important change coming!</h3>
             <p>We are making changes to the way you request assessment and approval for categories.</p>
-            <p>From X July 2019 instead of being assessed through case studies, you must prove your ability against individual criteria based on your previous work.</p>
+            <p>From 15 July 2019 instead of being assessed through case studies, you must prove your ability against individual criteria based on your previous work.</p>
           </div>
           <br />
           <p>Case studies are important for showing you meet our <a href="/assessment-criteria" target="_blank" rel="external">assessment criteria</a> for any new

--- a/src/bundles/CaseStudy/components/DomainList/DomainList.test.js
+++ b/src/bundles/CaseStudy/components/DomainList/DomainList.test.js
@@ -32,7 +32,6 @@ describe('<DomainList />', () => {
     );
     expect(wrapper.find('h1').text()).toBe('Case Study Domain List');
     expect(wrapper.find('h2').text()).toBe('Essential');
-    expect(wrapper.find('h3').text()).toBe('Agile delivery and Governance');
   });
 
   it('should render recommended domains', () => {
@@ -46,7 +45,6 @@ describe('<DomainList />', () => {
     );
     expect(wrapper.find('h1').text()).toBe('Case Study Domain List');
     expect(wrapper.find('h2').text()).toBe('Recommended');
-    expect(wrapper.find('h3').text()).toBe('Agile delivery and Governance');
   });
 
   it('should render existing supplier copy', () => {


### PR DESCRIPTION
This PR will add a warning message to the seller profile flow on the case study stage, warning them of the incoming changes to the assessment process.

We don't yet have a firm date on the new assessment flow release, but this warning message will be released ~2 weeks before the new flow release.