### PR TITLE
Allow searching for sellers with 2 characters

### DIFF
--- a/apps/marketplace/components/SellerSelect/SellerSelect.js
+++ b/apps/marketplace/components/SellerSelect/SellerSelect.js
@@ -230,7 +230,7 @@ SellerSelect.defaultProps = {
   showCategorySelect: false,
   allSuppliers: false,
   categories: [],
-  minimumSearchChars: 3,
+  minimumSearchChars: 2,
   onSellerSelect: () => {},
   onSellerCategorySelect: () => {},
   onSearch: () => {},

--- a/apps/marketplace/components/SellerSelect/SellerSelect.test.js
+++ b/apps/marketplace/components/SellerSelect/SellerSelect.test.js
@@ -54,22 +54,22 @@ describe('tests that generate network requests', () => {
 
   jest.useFakeTimers()
 
-  test('component sends a network request on input text change when the value is 3 or more chars in length', async () => {
+  test('component sends a network request on input text change when the value is 2 or more chars in length', async () => {
     const component = mount(<SellerSelect />)
 
     await component
       .find('input[type="text"]')
       .at(0)
-      .simulate('change', { target: { value: 'ab' } })
+      .simulate('change', { target: { value: 'a' } })
     await jest.runAllTimers()
     expect(server.requests.length).toBe(0)
 
     await component
       .find('input[type="text"]')
       .at(0)
-      .simulate('change', { target: { value: 'abc' } })
+      .simulate('change', { target: { value: 'ab' } })
     await jest.runAllTimers()
     expect(server.requests.length).toBe(1)
-    expect(server.requests[0].url).toEqual('/api/2/suppliers/search?keyword=abc&category=&all=')
+    expect(server.requests[0].url).toEqual('/api/2/suppliers/search?keyword=ab&category=&all=')
   })
 })

--- a/src/bundles/Search/redux/modules/search.js
+++ b/src/bundles/Search/redux/modules/search.js
@@ -167,8 +167,8 @@ export const search = (type, value, options = {}) => {
     // Update either role, type or keyword.
     dispatch({ type, value });
 
-    // don't search for less than 3 characters
-    if (!doSearch || !value || value.length < 3) {
+    // don't search for less than 2 characters
+    if (!doSearch || !value || value.length < 2) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
This PR changes the seller select component (used in RFX flow) and the seller catalogue search to trigger/allow searching when a minimum of 2 characters are provided, rather than 3. This is to address the issue where sellers with only two characters in their name required appending the `%` wildcard to be selectable/searchable.