### PR TITLE
Remove case study references from seller profile flow

### DIFF
--- a/src/bundles/SellerRegistration/components/DocumentsForm/DocumentsForm.js
+++ b/src/bundles/SellerRegistration/components/DocumentsForm/DocumentsForm.js
@@ -152,7 +152,7 @@ class DocumentsForm extends BaseForm {
                     <ValidationSummary form={form} applicationErrors={applicationErrors} filterFunc={(ae) => ae.step === 'documents' && type === 'edit'} />
                     <h1 className="au-display-xl" tabIndex="-1">Upload your documents</h1>
 
-                    <p>Your insurance documents will appear on your seller profile and your financial statement may be shared with buyers on request. So make sure they are up to date.</p>
+                    <p>The details of your insurance documents and financial statement are not visible on your profile (other than the insurance expiry dates). These details may be shared with buyers on request, so make sure they are up to date.</p>
                     <p>  Each should be no larger than 5MB and in PDF, PNG or JPEG format. If you have multiple files for a document, please scan and merge as one upload.
                   </p>
                     <br />

--- a/src/bundles/SellerRegistration/components/ProductsForm/ProductsForm.js
+++ b/src/bundles/SellerRegistration/components/ProductsForm/ProductsForm.js
@@ -73,15 +73,13 @@ class ProductsForm extends BaseForm {
         <header styleName="styles.content">
           <ValidationSummary form={form} applicationErrors={applicationErrors} filterFunc={(ae) => ae.step === 'products' && type === 'edit'} />
           <h1 className="au-display-xl" styleName="styles.content-heading" tabIndex="-1">Products</h1>
-            <p>If your business has developed any digital products, you can now offer them through the Digital Marketplace. Just remember they have to be your own, not a product you are reselling.</p>
-            <p>This feature is an MVP, meaning we want to learn more about the types of products sellers are offering so we can create a solution for selling them through the Digital Marketplace.</p>
+            <p>If your business has developed any digital products, you can now showcase them through your profile. Just remember, they have to be your own proprietary products.</p>
 
           {hasProducts && [<div className="calloutMistake">
             <b> Avoid common mistakes </b>
             <ul className="mistake-list">
-              <li>Make sure the product is your own</li>
-              <li>Only provide details for proprietary products being sold, not services offered by the company.</li>
-              <li>The Digital Marketplace does not currently support hardware products.</li>
+              <li>Only provide details for your own proprietary products, not services offered by the company.</li>
+              <li>Do not include hardware products.</li>
               <li>If using acronyms, their meaning must be written out clearly.</li>
               <li><b>Product links</b> - consider targeting URLs to pricing and support pages for the product rather than a generic landing page.</li>
               <li>Check that all URLs provided are working.</li>

--- a/src/bundles/SellerRegistration/components/ProductsForm/ProductsForm.js
+++ b/src/bundles/SellerRegistration/components/ProductsForm/ProductsForm.js
@@ -73,7 +73,7 @@ class ProductsForm extends BaseForm {
         <header styleName="styles.content">
           <ValidationSummary form={form} applicationErrors={applicationErrors} filterFunc={(ae) => ae.step === 'products' && type === 'edit'} />
           <h1 className="au-display-xl" styleName="styles.content-heading" tabIndex="-1">Products</h1>
-            <p>If your business has developed any digital products, you can now showcase them through your profile. Just remember, they have to be your own proprietary products.</p>
+            <p>If your business has developed any digital products, you can showcase them through your profile. Just remember, they have to be your own proprietary products.</p>
 
           {hasProducts && [<div className="calloutMistake">
             <b> Avoid common mistakes </b>

--- a/src/bundles/SellerRegistration/components/Signup/__snapshots__/Signup.snaps.test.js.snap
+++ b/src/bundles/SellerRegistration/components/Signup/__snapshots__/Signup.snaps.test.js.snap
@@ -203,7 +203,7 @@ exports[`Signup renders 1`] = `
           Joining the Digital Marketplace
         </h1>
         <p>
-          To become a registered seller and offer your services or software products to government you need to tell us about your business. 
+          To become a registered seller and offer your services or software products to government you need to tell us about your business. The information you share will be used to create your seller profile.
         </p>
         <p>
           By completing this application you are automatically responding to an open approach to market, whose terms and conditions, like other government tenders, are 
@@ -215,20 +215,6 @@ exports[`Signup renders 1`] = `
             publicly available.
           </a>
         </p>
-        <p>
-           The information you share will be used to create your seller profile. If you offer services it will also be used to confirm you meet the 
-          <a
-            href="/assessment-criteria"
-            rel="external"
-            target="_blank"
-          >
-            assessment criteria
-          </a>
-           when you express interest in opportunities.
-        </p>
-        <p>
-           It may take more than one visit to complete this application. But do not worry, your information will be saved automatically if you need to come back later.
-        </p>
         <h2
           className="au-display-lg"
         >
@@ -236,29 +222,16 @@ exports[`Signup renders 1`] = `
         </h2>
         <ul>
           <li>
-            Your basic business information
+            your basic business information
           </li>
           <li>
-            Recent financial records or a viability statement from your accountant
+            recent financial records or a viability statement from your accountant
           </li>
           <li>
-            Proof of relevant insurance cover
-          </li>
-        </ul>
-        <h2
-          className="au-display-lg"
-        >
-          You will be asked to
-        </h2>
-        <ul>
-          <li>
-            Share details about services or products you wish to provide
+            proof of relevant insurance cover
           </li>
           <li>
-             Provide case studies and referees to support your application
-          </li>
-          <li>
-            Accept the Digital Marketplace Master Agreement
+            to accept the Digital Marketplace Master Agreement
           </li>
         </ul>
         <p>
@@ -267,10 +240,13 @@ exports[`Signup renders 1`] = `
             rel="external"
             target="_blank"
           >
-            Download Digital Marketplace Master Agreement (PDF 229kb)
+            Download Digital Marketplace Master Agreement (PDF 245KB)
           </a>
           <br />
           <br />
+        </p>
+        <p>
+          You can save the progress of your application by selecting "Save and continue". If you wish to leave and come back later, select "Save and finish later".
         </p>
         <div />
         <p>

--- a/src/bundles/SellerRegistration/components/Start.js
+++ b/src/bundles/SellerRegistration/components/Start.js
@@ -22,31 +22,21 @@ const Start = ({supplierCode, signup, onClick, saved, type, applicationErrors })
                     <h1 className="au-display-xl">Joining the Digital Marketplace</h1>
                     <p>
                         To become a registered seller and offer your services or software products to government you need to
-                        tell us about your business. </p>
+                        tell us about your business. The information you share will be used to create your seller profile.</p>
                     <p>By completing this application you are automatically responding to an open approach to market, whose terms and
                         conditions, like other government tenders, are <a href="http://tenders.gov.au" target="_blank" rel="external">publicly available.</a></p>
-                    <p> The information you share will be used to create your seller profile. If you offer services it will
-                        also be used to confirm you meet the <a
-                            href="/assessment-criteria" target="_blank" rel="external">assessment criteria</a> when you
-                        express interest in opportunities.</p>
-                    <p> It may take more than one visit to complete this application. But do not worry, your information will
-                        be saved automatically if
-                        you need to come back later.
-                    </p>
                     <h2 className="au-display-lg">You will need</h2>
                     <ul>
-                        <li>Your basic business information</li>
-                        <li>Recent financial records or a viability statement from your accountant</li>
-                        <li>Proof of relevant insurance cover</li>
-                    </ul>
-                    <h2 className="au-display-lg">You will be asked to</h2>
-                    <ul>
-                        <li>Share details about services or products you wish to provide</li>
-                        <li> Provide case studies and referees to support your application</li>
-                        <li>Accept the Digital Marketplace Master Agreement</li>
+                        <li>your basic business information</li>
+                        <li>recent financial records or a viability statement from your accountant</li>
+                        <li>proof of relevant insurance cover</li>
+                        <li>to accept the Digital Marketplace Master Agreement</li>
                     </ul>
                     <p>
-                        <a href="/api/2/r/master-agreement-current.pdf" target="_blank" rel="external">Download Digital Marketplace Master Agreement (PDF 229kb)</a><br/><br/>
+                        <a href="/api/2/r/master-agreement-current.pdf" target="_blank" rel="external">Download Digital Marketplace Master Agreement (PDF 245KB)</a><br/><br/>
+                    </p>
+                    <p>
+                        You can save the progress of your application by selecting "Save and continue". If you wish to leave and come back later, select "Save and finish later".
                     </p>
                     <SaveError/>
                     <p>
@@ -57,12 +47,12 @@ const Start = ({supplierCode, signup, onClick, saved, type, applicationErrors })
                     <div>
                         <ValidationSummary applicationErrors={applicationErrors} title={'Application Errors'} />
                         <h1 className="au-display-xl">Update your profile</h1>
-                        <p>If you are interested in applying for a brief, update your profile to show experience in the relevant area of expertise.
-                           You can do this by adding more services with supporting case studies.</p>
-                        <p>Your case study must include a referee and examples of how you meet the <a
-                                href="/assessment-criteria" target="_blank" rel="external">assessment criteria</a>. Use the <a
-                                href="https://marketplace.service.gov.au/static/media/documents/Digital%20Marketplace%20case%20study%20template.xlsx" target="_blank" rel="external">spreadsheet template</a> if
-                            you need to collaborate on your case studies with colleagues.</p>
+                        <p>You must submit all your updates to be reviewed by the Marketplace. To submit updates:</p>
+                        <ul>
+                            <li>select 'Save and continue' on every page changes are made.</li>
+                            <li>go to the 'Preview and submit' tab and select 'Preview and submit updates'.</li>
+                            <li>select 'Submit updates'.</li>
+                        </ul>
                         <h2 className="au-display-lg">What happens next</h2>
                         <p>Once you submit the updates, we will review your updated profile and let you know once it is live.
                            Please note you cannot edit your profile while it is being reviewed.</p>
@@ -83,18 +73,10 @@ const Start = ({supplierCode, signup, onClick, saved, type, applicationErrors })
                         <p>We recommend adding case studies for services you are already approved to offer. For additional
                             services you will need to provide case studies and referees to confirm you meet our <a
                                 href="/assessment-criteria" target="_blank" rel="external">assessment criteria</a>.</p>
-                        <p>It may take more than one visit to complete your profile update. But do not worry, your information
-                            will be saved as you go.</p>
                         <h2 className="au-display-lg">You will need</h2>
                         <ul>
                             <li> Recent financial records or a viability statement from your accountant</li>
                             <li> Proof of current insurance cover</li>
-                        </ul>
-                        <h2 className="au-display-lg">You will be asked to</h2>
-                        <ul>
-                            <li>Share details about services or products you wish to provide</li>
-                            <li> Provide case studies and referees to support your application</li>
-                            <li>Accept the Digital Marketplace Master Agreement</li>
                         </ul>
                         <a href="/api/2/r/master-agreement-current.pdf" target="_blank" rel="external">Download Digital Marketplace Master Agreement PDF</a><br/><br/>
                         <SaveError/>

--- a/src/bundles/SellerRegistration/components/ToolsForm/ToolsForm.js
+++ b/src/bundles/SellerRegistration/components/ToolsForm/ToolsForm.js
@@ -39,13 +39,11 @@ class ToolsForm extends BaseForm {
                 <header styleName="content">
                     <ValidationSummary form={form} applicationErrors={applicationErrors} filterFunc={(ae) => ae.step === 'tools' && type === 'edit'} />
                     <h1 className="au-display-xl" styleName="content-heading" tabIndex="-1">Tools and methodologies</h1>
-                    <p>Enhance your profile and give buyers more ways to find you when searching</p>
 
                   <div className="calloutMistake">
                     <b> Avoid common mistakes </b>
                     <ul className="mistake-list">
                       <li>If using acronyms, their meaning must be written out clearly.</li>
-                      <li>If a section does not apply to your business, leave it blank. The section will not appear on your profile.</li>
                       <li>Use plain english to explain the tools, methodologies and technologies used.</li>
                     </ul>
                   </div>


### PR DESCRIPTION
This is to be released with the new seller assessment flow - late changes to the seller profile edit flow to remove text references to case studies.