### PR TITLE
[Opportunity] Set default number of specialist candidates

### DIFF
--- a/apps/marketplace/components/Opportunity/OpportunitySpecialistInfoCard.js
+++ b/apps/marketplace/components/Opportunity/OpportunitySpecialistInfoCard.js
@@ -271,7 +271,7 @@ OpportunitySpecialistInfoCard.defaultProps = {
   isAwaitingApplicationAssessment: false,
   isAwaitingDomainAssessment: false,
   isBriefOwner: false,
-  numberOfSuppliers: '',
+  numberOfSuppliers: '6',
   hasSupplierErrors: false,
   isInvited: false,
   hasSignedCurrentAgreement: false,


### PR DESCRIPTION
When a new draft specialist opportunity is created, the card is missing the number of candidates that can be submitted.  This pull request sets the default prop to 6.

### Before
![Screen Shot 2019-08-29 at 9 55 24 am](https://user-images.githubusercontent.com/2645932/63900277-5fc6e280-ca43-11e9-80b9-277ca85de590.png)

### After
![Screen Shot 2019-08-29 at 9 58 00 am](https://user-images.githubusercontent.com/2645932/63900317-81c06500-ca43-11e9-8a4d-5cfc90194d36.png)


Addresses MAR-3387