### PR TITLE
Revert "[a11y] Make the file upload accessible via keyboard (#827)"

### DIFF
--- a/apps/marketplace/components/ProgressFlow/ProgressContent.js
+++ b/apps/marketplace/components/ProgressFlow/ProgressContent.js
@@ -19,7 +19,7 @@ export class ProgressContent extends Component {
   render() {
     const StageComponent = this.props.component
     return (
-      <div ref={this.element} className={styles.container}>
+      <div tabIndex="0" ref={this.element} className={styles.container}>
         <StageComponent
           model={this.props.model}
           meta={this.props.meta}

--- a/apps/shared/form/FileInput.js
+++ b/apps/shared/form/FileInput.js
@@ -7,16 +7,10 @@ import StatefulError from './StatefulError'
 import styles from './scss/FileInput.scss'
 
 class FileInput extends React.Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      uploading: undefined,
-      file: undefined,
-      errors: undefined
-    }
-
-    this.uploadInput = null
+  state = {
+    uploading: undefined,
+    file: undefined,
+    errors: undefined
   }
 
   onReset = e => {
@@ -52,11 +46,6 @@ class FileInput extends React.Component {
       uploading(false)
     })
   }
-
-  onUploadClick = () => {
-    this.uploadInput.click()
-  }
-
   render() {
     const { url, form, name, id, model, validators, messages, fieldLabel, title, accept } = this.props
     const fileField = `${id}`
@@ -80,16 +69,10 @@ class FileInput extends React.Component {
                 onChange={this.onChange}
                 className={styles.hidden_input}
                 validators={validators}
-                tabIndex={-1}
                 title={title || ''}
-                getRef={ref => {
-                  this.uploadInput = ref
-                }}
               />
               <label htmlFor={`file_${fileField}`} id={`label_${id}`} className={styles.custom_input}>
-                <button className="au-btn au-btn--secondary" onClick={this.onUploadClick} type="button">
-                  {fieldLabel}
-                </button>
+                <div className="au-btn au-btn--secondary">{fieldLabel}</div>
               </label>
               {messages && (
                 <StatefulError


### PR DESCRIPTION
This reverts https://github.com/AusDTO/dto-digitalmarketplace-frontend/pull/827, as this broke file uploads in Safari due to how Safari prevents JS from executing click events on button elements that were not clicked on by the user.

This is a quick fix to allow Safari file uploading again while a Safari compatible solution is sought for the previous a11y file uploading ticket.