### PR TITLE
mar-3348 - updating content on seller profile

### DIFF
--- a/src/shared/SellerProfile/ReviewHeader.js
+++ b/src/shared/SellerProfile/ReviewHeader.js
@@ -110,7 +110,7 @@ const ReviewHeader = (props) => {
           {public_profile === false && (
             <article className="col-xs-12 col-sm-3 col-sm-push-1">
               <div className="seller-profile__tile" styleName="tile">
-                <p><b>Update the services you offer</b></p>
+                <p><b>Update your company details</b></p>
                 <a href="/sellers/edit" className="button" styleName="external-link white external-link-hover">Update profile</a>
               </div>  
             </article>


### PR DESCRIPTION
On a seller profile, the 'update profile' card's heading says 'Update the services you offer',
it is now changed to 'Update your company details