### PR TITLE
Add recruitment badge for seller catalogue search result cards

### DIFF
--- a/src/shared/Badges/Badges.js
+++ b/src/shared/Badges/Badges.js
@@ -6,6 +6,7 @@ import styles from './Badges.css'; // eslint-disable-line no-unused-vars
 
 export const titleMap = {
   recruiter_only: 'Recruiter',
+  recruitment: 'Recruiter',
   consultant_only: 'Consultant',
   recruiter_both: 'Recruiter and Consultant',
   indigenous: 'Indigenous business',


### PR DESCRIPTION
https://github.com/AusDTO/dto-digitalmarketplace-frontend/pull/808/files changed the way the badges work on the supplier's profile page but seemingly broke the 'Recruiter' badge from showing up in the supplier catalogue search result cards, as the cards are given a true/false `recruiter` property. This PR restores the `recruiter` badge property to accomodate the search result cards but shouldn't affect the full profile page.