### PR TITLE
Mar 3465

### DIFF
--- a/apps/marketplace/components/BuyerBriefFlow/BuyerEvaluationCriteriaStage.js
+++ b/apps/marketplace/components/BuyerBriefFlow/BuyerEvaluationCriteriaStage.js
@@ -14,7 +14,7 @@ import styles from './BuyerEvaluationCriteriaStage.scss'
 const noEmptyWeightingsEssential = v =>
   !v.includeWeightingsEssential || v.essentialRequirements.every(val => val.weighting)
 
-export const weightingsAddUpTo100Essential = v =>
+const weightingsAddUpTo100Essential = v =>
   !v.includeWeightingsEssential ||
   !noEmptyWeightingsEssential(v) ||
   v.essentialRequirements.reduce(

--- a/apps/marketplace/components/BuyerBriefFlow/BuyerEvaluationCriteriaStage.js
+++ b/apps/marketplace/components/BuyerBriefFlow/BuyerEvaluationCriteriaStage.js
@@ -14,7 +14,7 @@ import styles from './BuyerEvaluationCriteriaStage.scss'
 const noEmptyWeightingsEssential = v =>
   !v.includeWeightingsEssential || v.essentialRequirements.every(val => val.weighting)
 
-const weightingsAddUpTo100Essential = v =>
+export const weightingsAddUpTo100Essential = v =>
   !v.includeWeightingsEssential ||
   !noEmptyWeightingsEssential(v) ||
   v.essentialRequirements.reduce(

--- a/apps/marketplace/components/BuyerBriefFlow/BuyerEvaluationCriteriaStage.js
+++ b/apps/marketplace/components/BuyerBriefFlow/BuyerEvaluationCriteriaStage.js
@@ -23,7 +23,8 @@ export const weightingsAddUpTo100Essential = v =>
   ) === 100
 
 const noZeroWeightingsEssential = v =>
-  !v.includeWeightingsEssential || v.essentialRequirements.every(val => parseInt(val.weighting, 10) > 0)
+  !v.includeWeightingsEssential ||
+  v.essentialRequirements.every(val => val.weighting === '' || parseInt(val.weighting, 10) > 0)
 
 const noEmptyCriteriaEssential = v => v.essentialRequirements.every(val => val.criteria)
 
@@ -34,12 +35,11 @@ const noEmptyCriteriaNiceToHave = v => v.niceToHaveRequirements.every(val => (va
 
 const weightingsAddUpTo100NiceToHave = v =>
   !v.includeWeightingsNiceToHave ||
-  (noEmptyWeightingsNiceToHave(v) &&
-    noEmptyCriteriaNiceToHave(v) &&
-    v.niceToHaveRequirements.reduce(
-      (accumulator, currentValue) => accumulator + parseInt(currentValue.weighting, 10),
-      0
-    ) === 100)
+  !noEmptyWeightingsNiceToHave(v) ||
+  v.niceToHaveRequirements.reduce(
+    (accumulator, currentValue) => accumulator + parseInt(currentValue.weighting, 10),
+    0
+  ) === 100
 
 const noZeroWeightingsNiceToHave = v =>
   noEmptyCriteriaNiceToHave(v) ||


### PR DESCRIPTION
This will be solving 2 problems. 
1) described in the jira ticket
2) When there is a blank weighting the error of weights being greater than 0 should no longer show up
![image](https://user-images.githubusercontent.com/31645577/73812889-7b27ec00-4832-11ea-82a5-27dcaa93569e.png)

Yes - I will be updating the ui automation testing
