### PR TITLE
[Packages] Bump node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     ]
   },
   "engines": {
-    "node": "8.x"
+    "node": "10.x"
   },
   "pancake": {
     "auto-save": true,


### PR DESCRIPTION
This PR bumps the node version since Cloud Foundry have dropped support for v8 from their build packs.