### PR TITLE
Fix admin agency editing for Edge

### DIFF
--- a/src/bundles/ApplicationsAdmin/components/Agency/Agency.js
+++ b/src/bundles/ApplicationsAdmin/components/Agency/Agency.js
@@ -44,6 +44,9 @@ class Agency extends React.Component {
       data.whitelisted = false
     }
     data.domains = data.domains.split('\n')
+    // clean out any trailing white space and remove any empty rows
+    data.domains = data.domains.map(x => x.trim())
+    data.domains = data.domains.filter(x => x)
 
     this.setState({
       loading: true

--- a/src/bundles/ApplicationsAdmin/components/Agency/Agency.js
+++ b/src/bundles/ApplicationsAdmin/components/Agency/Agency.js
@@ -27,7 +27,10 @@ class Agency extends React.Component {
   handleSubmit(event) {
     event.preventDefault()
     const formData = new FormData(event.target)
-    let data = Object.fromEntries(formData)
+    let data = [...formData].reduce((obj, [key, val]) => {
+      obj[key] = val
+      return obj
+    }, {})
     const { agency } = this.state
     data.id = agency.id
     if (data.reports === "on") {


### PR DESCRIPTION
There is currently an issue in the admin portal, where by Edge users can't save agency details, because the form save uses the `Object.fromEntries` API, which is not supported in IE/Edge. This PR changes that into the "ponyfill" here:

https://github.com/feross/fromentries/blob/master/index.js

Also, while fixing this, I noticed that for agencies with multiple domains (e.g. DTA), the form save splits on `\n` to create an array of domains from the textarea input, but it doesn't strip out the `\r`, so domains that weren't on the last line were saving with an incorrect value - this PR fixes that by trimming out whitespace from each domain. Also, it was allowing empty lines to create empty domain values, which this PR also fixes.