### PR TITLE
Mar-3954 Remove area of expertise in the seller catalogue

### DIFF
--- a/src/bundles/Search/components/Catalogue/Catalogue.js
+++ b/src/bundles/Search/components/Catalogue/Catalogue.js
@@ -91,7 +91,7 @@ export class Catalogue extends React.Component {
                 <div>
                   <CheckboxList
                     id="role"
-                    title="Area of expertise"
+                    title="Categories"
                     list={search.role}
                     onChange={actions.updateRole}
                   />


### PR DESCRIPTION
Removing references of 'Areas of expertise' to 'Categories' in the seller catalogue.

There are other references of 'Areas of Expertise' in the code but these pages aren't accessed by the seller. I put in a ticket to remove dead code.  