### PR TITLE
Change team lead and member description text

### DIFF
--- a/apps/marketplace/components/Teams/Flows/TeamLeadNameDescription.js
+++ b/apps/marketplace/components/Teams/Flows/TeamLeadNameDescription.js
@@ -1,16 +1,9 @@
 import React from 'react'
 
-import styles from './TeamStages.scss'
-
-const TeamLeadNameDescription = props => {
-  const { domain } = props
-
-  return (
-    <span>
-      Team leads must already have a Digital Marketplace account in their name that ends in{' '}
-      <span className={styles.bold}>@{domain}</span>.
-    </span>
-  )
-}
+const TeamLeadNameDescription = () => (
+  <span>
+    Leads must be from your government organisation and already have a Digital Marketplace account registered.
+  </span>
+)
 
 export default TeamLeadNameDescription

--- a/apps/marketplace/components/Teams/Flows/TeamMemberNameDescription.js
+++ b/apps/marketplace/components/Teams/Flows/TeamMemberNameDescription.js
@@ -1,16 +1,9 @@
 import React from 'react'
 
-import styles from './TeamStages.scss'
-
-const TeamMemberNameDescription = props => {
-  const { domain } = props
-
-  return (
-    <span>
-      Members must already have a Digital Marketplace account in their name that ends in{' '}
-      <span className={styles.bold}>@{domain}</span>.
-    </span>
-  )
-}
+const TeamMemberNameDescription = () => (
+  <span>
+    Members must be from your government organisation and already have a Digital Marketplace account registered.
+  </span>
+)
 
 export default TeamMemberNameDescription


### PR DESCRIPTION
This PR rewords the description text for the team lead and team member selectors, so there is no longer a reference to the user needing to be from a specific email domain, since the check is now done by agency id and no longer reliant on email domain.

Since the release of the `agency_domain` work (i.e. an agency being able to have multiple domains), this was broken and displayed an empty value.