### PR TITLE
Mar 3977 - Unclear error message - valid date unspecified

### DIFF
--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
@@ -4,18 +4,23 @@ import { connect } from 'react-redux'
 import { Form, actions } from 'react-redux-form'
 import Textfield from 'shared/form/Textfield'
 import formProps from 'shared/form/formPropsSelector'
-import { required, dateIs2DaysInFuture, validDate } from 'marketplace/components/validators'
+import { required, dateIs2DaysInFuture, validDate, dateIsInPast } from 'marketplace/components/validators'
 import AUheadings from '@gov.au/headings/lib/js/react.js'
 import ErrorAlert from 'marketplace/components/Alerts/ErrorAlert'
 import DateControl from 'marketplace/components/BuyerBriefFlow/DateControl'
 
 const contractLengthRequired = v => required(v.contractLength)
 const startDateRequired = v => required(v.startDate)
-const startDateIsValid = v => validDate(v.startDate)
+const startDateIsValid = v => validDate(v.startDate) || !dateIsInPast(v.startDate)
 const startDateIs2DaysInFuture = v => !startDateRequired(v) || !startDateIsValid(v) || dateIs2DaysInFuture(v.startDate)
+const startDateIsNotInPast = v => !startDateRequired(v) || !startDateIsValid(v) || !startDateIs2DaysInFuture(v) || dateIsInPast(v.startDate)
 
 export const done = v =>
-  startDateRequired(v) && startDateIsValid(v) && startDateIs2DaysInFuture(v) && contractLengthRequired(v)
+  startDateRequired(v) &&
+  startDateIsValid(v) &&
+  startDateIs2DaysInFuture(v) &&
+  contractLengthRequired(v) 
+  // &&startDateIsNotInPast(v)
 
 class BuyerSpecialistTimeframesAndBudgetStage extends Component {
   constructor(props) {
@@ -41,7 +46,8 @@ class BuyerSpecialistTimeframesAndBudgetStage extends Component {
             startDateRequired,
             startDateIsValid,
             startDateIs2DaysInFuture,
-            contractLengthRequired
+            contractLengthRequired,
+            startDateIsNotInPast
           }
         }}
       >
@@ -54,7 +60,8 @@ class BuyerSpecialistTimeframesAndBudgetStage extends Component {
             startDateRequired: 'Enter an estimated start date for the opportunity',
             startDateIsValid: 'You must enter a valid start date',
             startDateIs2DaysInFuture: 'You must enter an estimated start date at least 2 days from now',
-            contractLengthRequired: 'Enter a contract length for the opportunity'
+            contractLengthRequired: 'Enter a contract length for the opportunity',
+            startDateIsNotInPast: 'You must enter a start date that is in the future.'
           }}
         />
         <DateControl

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
@@ -4,23 +4,18 @@ import { connect } from 'react-redux'
 import { Form, actions } from 'react-redux-form'
 import Textfield from 'shared/form/Textfield'
 import formProps from 'shared/form/formPropsSelector'
-import { required, dateIs2DaysInFuture, validDate, dateIsInPast } from 'marketplace/components/validators'
+import { required, dateIs2DaysInFuture, validDate } from 'marketplace/components/validators'
 import AUheadings from '@gov.au/headings/lib/js/react.js'
 import ErrorAlert from 'marketplace/components/Alerts/ErrorAlert'
 import DateControl from 'marketplace/components/BuyerBriefFlow/DateControl'
 
 const contractLengthRequired = v => required(v.contractLength)
 const startDateRequired = v => required(v.startDate)
-const startDateIsValid = v => validDate(v.startDate) || !dateIsInPast(v.startDate)
+const startDateIsValid = v => validDate(v.startDate)
 const startDateIs2DaysInFuture = v => !startDateRequired(v) || !startDateIsValid(v) || dateIs2DaysInFuture(v.startDate)
-const startDateIsNotInPast = v => !startDateRequired(v) || !startDateIsValid(v) || !startDateIs2DaysInFuture(v) || dateIsInPast(v.startDate)
 
 export const done = v =>
-  startDateRequired(v) &&
-  startDateIsValid(v) &&
-  startDateIs2DaysInFuture(v) &&
-  contractLengthRequired(v) 
-  // &&startDateIsNotInPast(v)
+  startDateRequired(v) && startDateIsValid(v) && startDateIs2DaysInFuture(v) && contractLengthRequired(v)
 
 class BuyerSpecialistTimeframesAndBudgetStage extends Component {
   constructor(props) {
@@ -46,8 +41,7 @@ class BuyerSpecialistTimeframesAndBudgetStage extends Component {
             startDateRequired,
             startDateIsValid,
             startDateIs2DaysInFuture,
-            contractLengthRequired,
-            startDateIsNotInPast
+            contractLengthRequired
           }
         }}
       >
@@ -60,8 +54,7 @@ class BuyerSpecialistTimeframesAndBudgetStage extends Component {
             startDateRequired: 'Enter an estimated start date for the opportunity',
             startDateIsValid: 'You must enter a valid start date',
             startDateIs2DaysInFuture: 'You must enter an estimated start date at least 2 days from now',
-            contractLengthRequired: 'Enter a contract length for the opportunity',
-            startDateIsNotInPast: 'You must enter a start date that is in the future.'
+            contractLengthRequired: 'Enter a contract length for the opportunity'
           }}
         />
         <DateControl

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
@@ -4,17 +4,20 @@ import { connect } from 'react-redux'
 import { Form, actions } from 'react-redux-form'
 import Textfield from 'shared/form/Textfield'
 import formProps from 'shared/form/formPropsSelector'
-import { required, dateIs2DaysInFuture, validDate, dateIsInPast } from 'marketplace/components/validators'
+import { required, dateIs2DaysInFuture, validDate } from 'marketplace/components/validators'
 import AUheadings from '@gov.au/headings/lib/js/react.js'
 import ErrorAlert from 'marketplace/components/Alerts/ErrorAlert'
 import DateControl from 'marketplace/components/BuyerBriefFlow/DateControl'
 
 const contractLengthRequired = v => required(v.contractLength)
 const startDateRequired = v => required(v.startDate)
-const startDateIsValid = v => validDate(v.startDate, false)
-const startDateIsInPast = v => !startDateRequired(v)  || validDate(v.startDate, true)
-const startDateIs2DaysInFuture = v => !startDateRequired(v) || !validDate(v.startDate, false) || !validDate(v.startDate, true) || dateIs2DaysInFuture(v.startDate)
-
+const startDateIsValid = v => !startDateRequired(v) || validDate(v.startDate, false)
+const startDateIsInPast = v => !startDateRequired(v) || validDate(v.startDate, true)
+const startDateIs2DaysInFuture = v =>
+  !startDateRequired(v) ||
+  !validDate(v.startDate, false) ||
+  !validDate(v.startDate, true) ||
+  dateIs2DaysInFuture(v.startDate)
 
 export const done = v =>
   startDateRequired(v) && startDateIsValid(v) && startDateIs2DaysInFuture(v) && contractLengthRequired(v)

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
@@ -12,12 +12,9 @@ import DateControl from 'marketplace/components/BuyerBriefFlow/DateControl'
 const contractLengthRequired = v => required(v.contractLength)
 const startDateRequired = v => required(v.startDate)
 const startDateIsValid = v => !startDateRequired(v) || validDate(v.startDate, false)
-const startDateIsInPast = v => !startDateRequired(v) || validDate(v.startDate, true)
+const startDateIsInPast = v => !startDateRequired(v) || validDate(v.startDate, true) || !validDate(v.startDate, false)
 const startDateIs2DaysInFuture = v =>
-  !startDateRequired(v) ||
-  !validDate(v.startDate, false) ||
-  !validDate(v.startDate, true) ||
-  dateIs2DaysInFuture(v.startDate)
+  !startDateRequired(v) || !startDateIsValid(v) || !startDateIsInPast(v) || dateIs2DaysInFuture(v.startDate)
 
 export const done = v =>
   startDateRequired(v) && startDateIsValid(v) && startDateIs2DaysInFuture(v) && contractLengthRequired(v)

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistTimeframesAndBudgetStage.js
@@ -4,15 +4,17 @@ import { connect } from 'react-redux'
 import { Form, actions } from 'react-redux-form'
 import Textfield from 'shared/form/Textfield'
 import formProps from 'shared/form/formPropsSelector'
-import { required, dateIs2DaysInFuture, validDate } from 'marketplace/components/validators'
+import { required, dateIs2DaysInFuture, validDate, dateIsInPast } from 'marketplace/components/validators'
 import AUheadings from '@gov.au/headings/lib/js/react.js'
 import ErrorAlert from 'marketplace/components/Alerts/ErrorAlert'
 import DateControl from 'marketplace/components/BuyerBriefFlow/DateControl'
 
 const contractLengthRequired = v => required(v.contractLength)
 const startDateRequired = v => required(v.startDate)
-const startDateIsValid = v => validDate(v.startDate)
-const startDateIs2DaysInFuture = v => !startDateRequired(v) || !startDateIsValid(v) || dateIs2DaysInFuture(v.startDate)
+const startDateIsValid = v => validDate(v.startDate, false)
+const startDateIsInPast = v => !startDateRequired(v)  || validDate(v.startDate, true)
+const startDateIs2DaysInFuture = v => !startDateRequired(v) || !validDate(v.startDate, false) || !validDate(v.startDate, true) || dateIs2DaysInFuture(v.startDate)
+
 
 export const done = v =>
   startDateRequired(v) && startDateIsValid(v) && startDateIs2DaysInFuture(v) && contractLengthRequired(v)
@@ -41,7 +43,8 @@ class BuyerSpecialistTimeframesAndBudgetStage extends Component {
             startDateRequired,
             startDateIsValid,
             startDateIs2DaysInFuture,
-            contractLengthRequired
+            contractLengthRequired,
+            startDateIsInPast
           }
         }}
       >
@@ -54,7 +57,8 @@ class BuyerSpecialistTimeframesAndBudgetStage extends Component {
             startDateRequired: 'Enter an estimated start date for the opportunity',
             startDateIsValid: 'You must enter a valid start date',
             startDateIs2DaysInFuture: 'You must enter an estimated start date at least 2 days from now',
-            contractLengthRequired: 'Enter a contract length for the opportunity'
+            contractLengthRequired: 'Enter a contract length for the opportunity',
+            startDateIsInPast: 'You must enter a start date that is in the future'
           }}
         />
         <DateControl

--- a/apps/marketplace/components/validators.js
+++ b/apps/marketplace/components/validators.js
@@ -5,7 +5,6 @@ import parse_date from 'date-fns/parse'
 import format from 'date-fns/format'
 import isValid from 'date-fns/is_valid'
 import isFuture from 'date-fns/is_future'
-import isPast from 'date-fns/is_past'
 import isAfter from 'date-fns/is_after'
 import isBefore from 'date-fns/is_before'
 import addDays from 'date-fns/add_days'
@@ -51,25 +50,6 @@ export const validDate = (val, enableFutureCheck) => {
   } else {
     return true
   }
-  return false
-}
-
-export const dateIsInPast = (val, enablePastCheck) => {
-  const dateObj = parse_date(val)
-  if (!val || !isValid(dateObj)) {
-    return false
-  }
-  if (format(dateObj, 'YYYY-MM-DD') !== val) {
-    return false
-  }
-  if (enablePastCheck === undefined || enablePastCheck) {
-    if (isPast(val)) {
-      return true
-    }
-  } 
-  // else {
-  //   return true
-  // }
   return false
 }
 

--- a/apps/marketplace/components/validators.js
+++ b/apps/marketplace/components/validators.js
@@ -5,6 +5,7 @@ import parse_date from 'date-fns/parse'
 import format from 'date-fns/format'
 import isValid from 'date-fns/is_valid'
 import isFuture from 'date-fns/is_future'
+import isPast from 'date-fns/is_past'
 import isAfter from 'date-fns/is_after'
 import isBefore from 'date-fns/is_before'
 import addDays from 'date-fns/add_days'
@@ -50,6 +51,25 @@ export const validDate = (val, enableFutureCheck) => {
   } else {
     return true
   }
+  return false
+}
+
+export const dateIsInPast = (val, enablePastCheck) => {
+  const dateObj = parse_date(val)
+  if (!val || !isValid(dateObj)) {
+    return false
+  }
+  if (format(dateObj, 'YYYY-MM-DD') !== val) {
+    return false
+  }
+  if (enablePastCheck === undefined || enablePastCheck) {
+    if (isPast(val)) {
+      return true
+    }
+  } 
+  // else {
+  //   return true
+  // }
   return false
 }
 


### PR DESCRIPTION
This PR will fix up a few things: 
1.  When a user puts in a date that is in the past, the error message will state **'You must enter a start date that is in the future.'** This will not remove or replace validStartDate function, instead this will only appear when the date is invalid, for instance a leap year.

2. When the form is empty, instead of getting 2 messages that says _'you must enter a valid start date'_ and _'Enter an estimated start date for the opportunity'_, it will only show _'Enter an estimated start date'_ 

The 2nd point wasn't in the ticket but I did it anyway since it didn't make much sense. I updated the UI automation test to reflect this.