### PR TITLE
Use framework in the links used by edit history components

### DIFF
--- a/apps/marketplace/components/Brief/OpportunityHistory.js
+++ b/apps/marketplace/components/Brief/OpportunityHistory.js
@@ -97,7 +97,7 @@ const OpportunityHistory = props => {
       {edits.length > 0 && edits.map(edit => <EditSummary edit={edit} key={edit.editedAt} />)}
       {edits.length === 0 && <p>No changes have been made to this opportunity.</p>}
       <div className={styles.marginTop2}>
-        <a href={`${rootPath}/digital-marketplace/opportunities/${brief.id}`}>Return to opportunity</a>
+        <a href={`${rootPath}/${brief.framework}/opportunities/${brief.id}`}>Return to opportunity</a>
       </div>
     </React.Fragment>
   )
@@ -110,6 +110,7 @@ OpportunityHistory.defaultProps = {
 
 OpportunityHistory.propTypes = {
   brief: PropTypes.shape({
+    framework: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired
   }).isRequired,

--- a/apps/marketplace/pages/OpportunityHistoryPage.js
+++ b/apps/marketplace/pages/OpportunityHistoryPage.js
@@ -72,7 +72,7 @@ class OpportunityHistoryPage extends Component {
 
     if (dataLoaded) {
       return (
-        <BrowserRouter basename={`${rootPath}/${brief.frameworkSlug}/opportunities/${brief.id}/history`}>
+        <BrowserRouter basename={`${rootPath}/${brief.framework}/opportunities/${brief.id}/history`}>
           <div className="col-xs-12">
             <Switch>
               <Route


### PR DESCRIPTION
This pull request fixes a problem where part of the base name of the router was becoming undefined when navigating to and from different routes.

Related - https://github.com/AusDTO/dto-digitalmarketplace-api/pull/758

Addresses MAR-4140