### PR TITLE
Return user to previous page on cancel edits

### DIFF
--- a/apps/marketplace/components/Brief/Edit/EditOpportunity.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunity.js
@@ -84,6 +84,11 @@ class EditOpportunity extends Component {
     const checkBoxValidator = this.validateEditProcessCheckBox
     const showCheckBox = this.showCheckBox()
 
+    const returnPath =
+      location.state && Object.prototype.hasOwnProperty.call(location.state, 'from') && location.state.from
+        ? location.state.from
+        : `${rootPath}/brief/${brief.id}/overview/${brief.lot}`
+
     return (
       <div className="col-xs-12">
         <Form
@@ -165,7 +170,7 @@ class EditOpportunity extends Component {
             <AUbutton onClick={this.handleSubmitClick} type="submit">
               Submit changes
             </AUbutton>
-            <AUbutton as="tertiary" link={`${rootPath}/brief/${brief.id}/overview/${brief.lot}`}>
+            <AUbutton as="tertiary" link={returnPath}>
               Cancel all updates
             </AUbutton>
           </div>

--- a/apps/marketplace/components/BuyerBriefFlow/Overview.js
+++ b/apps/marketplace/components/BuyerBriefFlow/Overview.js
@@ -243,6 +243,7 @@ class Overview extends Component {
 }
 
 Overview.defaultProps = {
+  location: {},
   oldWorkOrderCreator: true,
   questionsAsked: 0
 }
@@ -250,7 +251,7 @@ Overview.defaultProps = {
 Overview.propTypes = {
   brief: PropTypes.object.isRequired,
   flow: PropTypes.string.isRequired,
-  location: PropTypes.object.isRequired,
+  location: PropTypes.object,
   oldWorkOrderCreator: PropTypes.bool,
   questionsAsked: PropTypes.number
 }

--- a/apps/marketplace/components/BuyerBriefFlow/Overview.js
+++ b/apps/marketplace/components/BuyerBriefFlow/Overview.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Redirect } from 'react-router-dom'
+import { Link, Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { deleteBrief } from 'marketplace/actions/briefActions'
@@ -110,6 +110,7 @@ class Overview extends Component {
       briefResponses,
       canCloseOpportunity,
       flow,
+      location,
       oldWorkOrderCreator,
       questionsAsked,
       isPartOfTeam,
@@ -192,7 +193,14 @@ class Overview extends Component {
             {brief.status === 'live' && isPublished && (
               <li>
                 {hasPermission(isPartOfTeam, isTeamLead, teams, 'publish_opportunities') ? (
-                  <a href={`${rootPath}/brief/${brief.id}/edit`}>Edit live opportunity</a>
+                  <Link
+                    to={{
+                      pathname: `${rootPath}/brief/${brief.id}/edit`,
+                      state: { from: location.pathname }
+                    }}
+                  >
+                    Edit live opportunity
+                  </Link>
                 ) : (
                   <a href={`${rootPath}/request-access/publish_opportunities`}>Edit live opportunity</a>
                 )}
@@ -242,6 +250,7 @@ Overview.defaultProps = {
 Overview.propTypes = {
   brief: PropTypes.object.isRequired,
   flow: PropTypes.string.isRequired,
+  location: PropTypes.object.isRequired,
   oldWorkOrderCreator: PropTypes.bool,
   questionsAsked: PropTypes.number
 }

--- a/apps/marketplace/components/Opportunity/Opportunity.js
+++ b/apps/marketplace/components/Opportunity/Opportunity.js
@@ -116,6 +116,7 @@ const Opportunity = props => {
     isOpenToAll,
     isOpenToCategory,
     isBriefOwner,
+    location,
     loggedIn,
     hasResponded,
     isBuyer,
@@ -319,9 +320,9 @@ const Opportunity = props => {
                 <strong>Location of work</strong>
               </div>
               <div className="col-xs-12 col-sm-8">
-                {brief.location.map(location => (
-                  <span key={location}>
-                    {location}
+                {brief.location.map(state => (
+                  <span key={state}>
+                    {state}
                     <br />
                   </span>
                 ))}
@@ -664,6 +665,7 @@ const Opportunity = props => {
               hasSignedCurrentAgreement={hasSignedCurrentAgreement}
               supplierCode={supplierCode}
               originalClosedAt={originalClosedAt}
+              location={location}
             />
           )}
           {brief.status !== 'withdrawn' && brief.lotSlug !== 'specialist' && (
@@ -702,6 +704,7 @@ const Opportunity = props => {
               hasSignedCurrentAgreement={hasSignedCurrentAgreement}
               supplierCode={supplierCode}
               originalClosedAt={originalClosedAt}
+              location={location}
             />
           )}
         </div>
@@ -739,6 +742,7 @@ Opportunity.defaultProps = {
   isAwaitingDomainAssessment: false,
   hasBeenAssessedForBrief: false,
   hasResponded: false,
+  location: {},
   loggedIn: false,
   hasSupplierErrors: false,
   hasSignedCurrentAgreement: false,
@@ -819,6 +823,7 @@ Opportunity.propTypes = {
   isAwaitingDomainAssessment: PropTypes.bool,
   hasBeenAssessedForBrief: PropTypes.bool,
   hasResponded: PropTypes.bool,
+  location: PropTypes.object,
   loggedIn: PropTypes.bool,
   hasSupplierErrors: PropTypes.bool,
   hasSignedCurrentAgreement: PropTypes.bool,

--- a/apps/marketplace/components/Opportunity/OpportunityInfoCard.js
+++ b/apps/marketplace/components/Opportunity/OpportunityInfoCard.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { isBefore, parse } from 'date-fns'
 import ClosedDate from 'shared/ClosedDate'
@@ -31,6 +32,7 @@ const OpportunityInfoCard = props => {
     isOpenToAll,
     isOpenToCategory,
     isRecruiterOnly,
+    location,
     loggedIn,
     originalClosedAt,
     rejectedEvidenceId,
@@ -130,9 +132,15 @@ const OpportunityInfoCard = props => {
             </a>
           )}
           {isOpen && isBuyer && isBriefOwner && (
-            <a href={`${rootPath}/brief/${briefId}/edit`} className="au-btn au-btn--block">
+            <Link
+              className="au-btn au-btn--block"
+              to={{
+                pathname: `${rootPath}/brief/${briefId}/edit`,
+                state: { from: location.pathname }
+              }}
+            >
               Edit your opportunity
-            </a>
+            </Link>
           )}
           {isOpen && loggedIn && isApprovedSeller && !hasSignedCurrentAgreement && !hasResponded && (
             <span>
@@ -345,6 +353,7 @@ OpportunityInfoCard.defaultProps = {
   rejectedEvidenceId: undefined,
   isOpenToCategory: false,
   isOpenToAll: false,
+  location: {},
   loggedIn: false,
   hasResponded: false,
   isOpen: false,
@@ -374,6 +383,7 @@ OpportunityInfoCard.propTypes = {
   rejectedEvidenceId: PropTypes.number,
   isOpenToCategory: PropTypes.bool,
   isOpenToAll: PropTypes.bool,
+  location: PropTypes.object,
   loggedIn: PropTypes.bool,
   hasResponded: PropTypes.bool,
   isOpen: PropTypes.bool,

--- a/apps/marketplace/components/Opportunity/OpportunitySpecialistInfoCard.js
+++ b/apps/marketplace/components/Opportunity/OpportunitySpecialistInfoCard.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { isBefore, parse } from 'date-fns'
 import ClosedDate from 'shared/ClosedDate'
@@ -30,6 +31,7 @@ const OpportunitySpecialistInfoCard = props => {
     isOpen,
     isOpenToAll,
     isRecruiterOnly,
+    location,
     loggedIn,
     numberOfSuppliers,
     originalClosedAt,
@@ -178,9 +180,15 @@ const OpportunitySpecialistInfoCard = props => {
             </a>
           )}
           {isOpen && isBuyer && isBriefOwner && (
-            <a href={`${rootPath}/brief/${briefId}/edit`} className="au-btn au-btn--block">
+            <Link
+              className="au-btn au-btn--block"
+              to={{
+                pathname: `${rootPath}/brief/${briefId}/edit`,
+                state: { from: location.pathname }
+              }}
+            >
               Edit your opportunity
-            </a>
+            </Link>
           )}
           {isOpen && loggedIn && isApplicant && (
             <span>
@@ -326,6 +334,7 @@ OpportunitySpecialistInfoCard.defaultProps = {
   draftEvidenceId: undefined,
   rejectedEvidenceId: undefined,
   isOpenToAll: false,
+  location: {},
   loggedIn: false,
   hasResponded: false,
   isOpen: false,
@@ -358,6 +367,7 @@ OpportunitySpecialistInfoCard.propTypes = {
   draftEvidenceId: PropTypes.number,
   rejectedEvidenceId: PropTypes.number,
   isOpenToAll: PropTypes.bool,
+  location: PropTypes.object,
   loggedIn: PropTypes.bool,
   hasResponded: PropTypes.bool,
   isOpen: PropTypes.bool,

--- a/apps/marketplace/pages/BuyerBriefOverviewPage.js
+++ b/apps/marketplace/pages/BuyerBriefOverviewPage.js
@@ -65,6 +65,7 @@ class BuyerBriefOverviewPage extends Component {
         <Overview
           brief={this.props.brief}
           briefResponses={this.props.briefResponses}
+          location={this.props.location}
           oldWorkOrderCreator={this.props.oldWorkOrderCreator}
           questionsAsked={this.props.questionsAsked}
           flow={this.props.match.params.flow}

--- a/apps/marketplace/pages/OpportunityPage.js
+++ b/apps/marketplace/pages/OpportunityPage.js
@@ -113,6 +113,7 @@ class OpportunityPage extends Component {
           isInvited={this.props.isInvited}
           hasSignedCurrentAgreement={this.props.hasSignedCurrentAgreement}
           lastEditedAt={this.props.lastEditedAt}
+          location={this.props.location}
           onlySellersEdited={this.props.onlySellersEdited}
           supplierCode={this.props.supplierCode}
           userType={this.props.userType}


### PR DESCRIPTION
This pull request changes the behaviour of the cancel edits button which currently links to the overview even if the user was previously on the opportunity page.  The user will now be taken to the previous page that they were on or the overview if no previous page has been detected (eg. page is opened in a new tab).

Addresses MAR-4133