### PR TITLE
Vertically align edit opportunity table content

### DIFF
--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
@@ -65,18 +65,22 @@ class EditOpportunityTable extends Component {
       <React.Fragment>
         <table className={`col-xs-12 ${styles.hideMobile} ${styles.defaultStyle} ${styles.textAlignLeft}`}>
           <tbody>
-            <tr className={styles.verticalAlignTop}>
+            <tr className={`${styles.verticalAlignTop} ${localStyles.editSection}`}>
               <th scope="row">Opportunity title</th>
               <td>{itemWasEdited(brief.title, edits.title) ? edits.title : brief.title}</td>
               <td>
-                <Link to="/title" className="au-btn au-btn--tertiary">
+                <Link to="/title" className={`au-btn au-btn--tertiary ${localStyles.editAction}`}>
                   Edit title
                 </Link>
               </td>
             </tr>
             {showInvited && (
               <React.Fragment>
-                <tr className={`${sellersToInvite.length > 0 ? styles.borderBottom0 : ''} ${styles.verticalAlignTop}`}>
+                <tr
+                  className={`${styles.verticalAlignTop} ${localStyles.editSection} ${
+                    sellersToInvite.length > 0 ? styles.borderBottom0 : ''
+                  }`}
+                >
                   <th scope="row">Invited sellers</th>
                   <td>
                     <ul>
@@ -86,13 +90,13 @@ class EditOpportunityTable extends Component {
                     </ul>
                   </td>
                   <td>
-                    <Link to="/sellers" className="au-btn au-btn--tertiary">
+                    <Link to="/sellers" className={`au-btn au-btn--tertiary ${localStyles.editAction}`}>
                       {sellersToInvite.length > 0 ? 'Edit' : 'Add'} sellers
                     </Link>
                   </td>
                 </tr>
                 {sellersToInvite.length > 0 && (
-                  <tr className={styles.verticalAlignTop}>
+                  <tr className={`${styles.verticalAlignTop} ${localStyles.editSection}`}>
                     <th scope="row">Sellers to invite</th>
                     <td>
                       <ul>
@@ -106,27 +110,27 @@ class EditOpportunityTable extends Component {
                 )}
               </React.Fragment>
             )}
-            <tr className={styles.verticalAlignTop}>
+            <tr className={`${styles.verticalAlignTop} ${localStyles.editSection}`}>
               <th scope="row">Summary</th>
               <td className={styles.tableColumnWidth19}>
                 <SummaryPreview brief={brief} desktop edits={edits} previewHeight={64} />
               </td>
               <td>
-                <Link to="/summary" className="au-btn au-btn--tertiary">
+                <Link to="/summary" className={`au-btn au-btn--tertiary ${localStyles.editAction}`}>
                   Edit summary
                 </Link>
               </td>
             </tr>
-            <tr className={styles.verticalAlignTop}>
+            <tr className={`${styles.verticalAlignTop} ${localStyles.editSection}`}>
               <th scope="row">Documents</th>
               <td>{this.generateDocumentList()}</td>
               <td>
-                <Link to="/documents" className="au-btn au-btn--tertiary">
+                <Link to="/documents" className={`au-btn au-btn--tertiary ${localStyles.editAction}`}>
                   {getAllDocuments(brief).length > 0 || getAllDocuments(edits).length > 0 ? 'Edit' : 'Add'} documents
                 </Link>
               </td>
             </tr>
-            <tr className={styles.verticalAlignTop}>
+            <tr className={`${styles.verticalAlignTop} ${localStyles.editSection}`}>
               <th scope="row">Closing date</th>
               <td>
                 {itemWasEdited(format(new Date(brief.dates.closing_time), 'YYYY-MM-DD'), edits.closingDate)
@@ -134,7 +138,7 @@ class EditOpportunityTable extends Component {
                   : format(getClosingTime(brief), 'dddd DD MMMM YYYY [at] ha [(in Canberra)]')}
               </td>
               <td>
-                <Link to="/closing-date" className="au-btn au-btn--tertiary">
+                <Link to="/closing-date" className={`au-btn au-btn--tertiary ${localStyles.editAction}`}>
                   Extend closing date
                 </Link>
               </td>

--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
@@ -30,10 +30,10 @@ class EditOpportunityTable extends Component {
     return (
       <React.Fragment>
         {(getAllDocuments(brief).length > 0 || getAllDocuments(edits).length > 0) && (
-          <ul>
+          <ul className={localStyles.editList}>
             {edits.documentsEdited &&
               getAllDocuments(edits).map(document => (
-                <li key={document}>
+                <li className={styles.marginBottom1} key={document}>
                   <a href={`${documentBaseURL}${document}`} target="_blank" rel="noopener noreferrer">
                     {document}
                   </a>
@@ -41,7 +41,7 @@ class EditOpportunityTable extends Component {
               ))}
             {!edits.documentsEdited &&
               getAllDocuments(brief).map(document => (
-                <li key={document}>
+                <li className={styles.marginBottom1} key={document}>
                   <a href={`${documentBaseURL}${document}`} target="_blank" rel="noopener noreferrer">
                     {document}
                   </a>
@@ -83,9 +83,11 @@ class EditOpportunityTable extends Component {
                 >
                   <th scope="row">Invited sellers</th>
                   <td>
-                    <ul>
+                    <ul className={localStyles.editList}>
                       {Object.values(brief.sellers).map(seller => (
-                        <li key={seller.name}>{seller.name}</li>
+                        <li className={styles.marginBottom1} key={seller.name}>
+                          {seller.name}
+                        </li>
                       ))}
                     </ul>
                   </td>
@@ -99,9 +101,11 @@ class EditOpportunityTable extends Component {
                   <tr className={`${styles.verticalAlignTop} ${localStyles.editSection}`}>
                     <th scope="row">Sellers to invite</th>
                     <td>
-                      <ul>
+                      <ul className={localStyles.editList}>
                         {sellersToInvite.map(code => (
-                          <li key={edits.sellers[code].name}>{edits.sellers[code].name}</li>
+                          <li className={styles.marginBottom1} key={edits.sellers[code].name}>
+                            {edits.sellers[code].name}
+                          </li>
                         ))}
                       </ul>
                     </td>

--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
@@ -65,7 +65,7 @@ class EditOpportunityTable extends Component {
       <React.Fragment>
         <table className={`col-xs-12 ${styles.hideMobile} ${styles.defaultStyle} ${styles.textAlignLeft}`}>
           <tbody>
-            <tr>
+            <tr className={styles.verticalAlignTop}>
               <th scope="row">Opportunity title</th>
               <td>{itemWasEdited(brief.title, edits.title) ? edits.title : brief.title}</td>
               <td>
@@ -76,7 +76,7 @@ class EditOpportunityTable extends Component {
             </tr>
             {showInvited && (
               <React.Fragment>
-                <tr className={sellersToInvite.length > 0 ? styles.borderBottom0 : ''}>
+                <tr className={`${sellersToInvite.length > 0 ? styles.borderBottom0 : ''} ${styles.verticalAlignTop}`}>
                   <th scope="row">Invited sellers</th>
                   <td>
                     <ul>
@@ -92,7 +92,7 @@ class EditOpportunityTable extends Component {
                   </td>
                 </tr>
                 {sellersToInvite.length > 0 && (
-                  <tr>
+                  <tr className={styles.verticalAlignTop}>
                     <th scope="row">Sellers to invite</th>
                     <td>
                       <ul>
@@ -106,7 +106,7 @@ class EditOpportunityTable extends Component {
                 )}
               </React.Fragment>
             )}
-            <tr>
+            <tr className={styles.verticalAlignTop}>
               <th scope="row">Summary</th>
               <td className={styles.tableColumnWidth19}>
                 <SummaryPreview brief={brief} desktop edits={edits} previewHeight={64} />
@@ -117,7 +117,7 @@ class EditOpportunityTable extends Component {
                 </Link>
               </td>
             </tr>
-            <tr>
+            <tr className={styles.verticalAlignTop}>
               <th scope="row">Documents</th>
               <td>{this.generateDocumentList()}</td>
               <td>
@@ -126,7 +126,7 @@ class EditOpportunityTable extends Component {
                 </Link>
               </td>
             </tr>
-            <tr>
+            <tr className={styles.verticalAlignTop}>
               <th scope="row">Closing date</th>
               <td>
                 {itemWasEdited(format(new Date(brief.dates.closing_time), 'YYYY-MM-DD'), edits.closingDate)

--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.scss
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.scss
@@ -15,9 +15,5 @@
 
     .editList {
         margin-top: 0;
-
-        .editListItem {
-            margin-top: 0.5rem;
-        }
     }
 }

--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.scss
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.scss
@@ -3,6 +3,11 @@
         display: inline-block;
     }
 
+    .editAction {
+        border: none;
+        padding-top: 0;
+    }
+
     .editLink {
         border: none;
         padding: 0;

--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.scss
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.scss
@@ -12,4 +12,12 @@
         border: none;
         padding: 0;
     }
+
+    .editList {
+        margin-top: 0;
+
+        .editListItem {
+            margin-top: 0.5rem;
+        }
+    }
 }

--- a/apps/marketplace/main.scss
+++ b/apps/marketplace/main.scss
@@ -185,6 +185,10 @@
   padding-top: 1rem;
 }
 
+.verticalAlignTop {
+  vertical-align: top;
+}
+
 .whiteSpacePreWrap {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
This pull request vertically aligns content in the edit opportunity table so that headers and actions sit at the top.

### Before
<img width="1140" alt="Screen Shot 2020-04-30 at 2 42 48 pm" src="https://user-images.githubusercontent.com/2645932/80672619-a4ce7780-8af0-11ea-95c8-029164ef881f.png">

### After
<img width="1143" alt="Screen Shot 2020-04-30 at 2 42 16 pm" src="https://user-images.githubusercontent.com/2645932/80672666-b021a300-8af0-11ea-9720-3d7e735d423b.png">

Addresses MAR-4153