### PR TITLE
Add top border to first row in edit opportunity table

### DIFF
--- a/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunityTable.js
@@ -63,9 +63,11 @@ class EditOpportunityTable extends Component {
 
     return (
       <React.Fragment>
-        <table className={`col-xs-12 ${styles.hideMobile} ${styles.defaultStyle} ${styles.textAlignLeft}`}>
+        <table
+          className={`col-xs-12 ${styles.hideMobile} ${styles.defaultStyle} ${styles.textAlignLeft} ${styles.marginTop1}`}
+        >
           <tbody>
-            <tr>
+            <tr className={styles.borderTop1}>
               <th scope="row">Opportunity title</th>
               <td>{itemWasEdited(brief.title, edits.title) ? edits.title : brief.title}</td>
               <td>

--- a/apps/marketplace/main.scss
+++ b/apps/marketplace/main.scss
@@ -302,6 +302,10 @@ table.defaultStyle {
     &.borderBottom0 {
       border-bottom: none;
     }
+
+    &.borderTop1 {
+      border-top: solid 1px #bebebe;
+    }
   }
 
   &.striped tr:nth-child(2n) {


### PR DESCRIPTION
### Before
<img width="1137" alt="Screen Shot 2020-05-01 at 8 19 01 am" src="https://user-images.githubusercontent.com/2645932/80764506-2de2be80-8b84-11ea-894c-83be917f3756.png">

### After
<img width="1140" alt="Screen Shot 2020-05-01 at 8 18 22 am" src="https://user-images.githubusercontent.com/2645932/80764526-363af980-8b84-11ea-9edc-fd52149decfe.png">

Addresses MAR-4157