### PR TITLE
Update content for edited opportunity page alert

### DIFF
--- a/apps/marketplace/components/Brief/Edit/EditedOpportunity.js
+++ b/apps/marketplace/components/Brief/Edit/EditedOpportunity.js
@@ -10,6 +10,12 @@ import styles from '../../../main.scss'
 
 const EditedOpportunity = props => {
   const { app, brief, edits, onFeedbackSubmit, setFocus } = props
+  const singleSellerInvited = Object.keys(edits.sellers).length === 1
+  let seller = ''
+
+  if (edits.onlySellersEdited && singleSellerInvited) {
+    seller = Object.values(edits.sellers)[0].name
+  }
 
   return (
     <React.Fragment>
@@ -17,7 +23,9 @@ const EditedOpportunity = props => {
         <AUpageAlert as="success" setFocus={setFocus}>
           <h1 className="au-display-lg">
             <strong>
-              You have invited new seller/s to submit responses to {brief.title} ({brief.id})
+              {singleSellerInvited
+                ? `You have invited ${seller} to submit a response to ${brief.title} (${brief.id})`
+                : `You have invited additional sellers to submit responses to ${brief.title} (${brief.id})`}
             </strong>
           </h1>
           <div className={styles.marginTop2}>

--- a/apps/marketplace/components/Brief/Edit/EditedOpportunity.js
+++ b/apps/marketplace/components/Brief/Edit/EditedOpportunity.js
@@ -22,6 +22,9 @@ const EditedOpportunity = props => {
           </h1>
           <div className={styles.marginTop2}>
             <p>You can view all invited sellers by selecting the opportunity on your dashboard.</p>
+            <div className={styles.marginTop1}>
+              <AUbutton link={`${rootPath}/digital-marketplace/opportunities/${brief.id}`}>View opportunity</AUbutton>
+            </div>
           </div>
         </AUpageAlert>
       ) : (

--- a/apps/marketplace/components/Brief/Edit/EditedOpportunity.js
+++ b/apps/marketplace/components/Brief/Edit/EditedOpportunity.js
@@ -29,7 +29,7 @@ const EditedOpportunity = props => {
             </strong>
           </h1>
           <div className={styles.marginTop2}>
-            <p>You can view all invited sellers by selecting the opportunity on your dashboard.</p>
+            <p>You can view invited sellers by selecting the opportunity on your dashboard.</p>
             <div className={styles.marginTop1}>
               <AUbutton link={`${rootPath}/digital-marketplace/opportunities/${brief.id}`}>View opportunity</AUbutton>
             </div>


### PR DESCRIPTION
This pull request changes the message of the page alert to display the seller's name if only one seller has been added and only sellers were edited.

### Before
<img width="1162" alt="Screen Shot 2020-05-04 at 8 08 24 am" src="https://user-images.githubusercontent.com/2645932/80927040-87dec080-8dde-11ea-8c1d-5737b4ac6ae8.png">

### After
<img width="1162" alt="Screen Shot 2020-05-04 at 8 09 27 am" src="https://user-images.githubusercontent.com/2645932/80927049-91682880-8dde-11ea-8e63-3489c06b946d.png">
<img width="1160" alt="Screen Shot 2020-05-04 at 8 10 21 am" src="https://user-images.githubusercontent.com/2645932/80927052-97f6a000-8dde-11ea-9482-5abf6847fc0b.png">

Addresses MAR-4161