### PR TITLE
Make phone number validators consistent

### DIFF
--- a/apps/shared/validators.js
+++ b/apps/shared/validators.js
@@ -172,8 +172,9 @@ export const validPhoneNumber = val => {
     return true
   }
 
-  const length = (val.match(/[0-9]/g) || []).length
-  return length >= 10
+  const numberCount = (val.match(/[0-9]/g) || []).length
+  const validCharCount = (val.match(/[ 0-9()+]/g) || []).length
+  return val.length === validCharCount && numberCount >= 10
 }
 
 export const passwordsMatch = vals => vals.password === vals.confirmPassword

--- a/src/validators.js
+++ b/src/validators.js
@@ -167,13 +167,13 @@ export const validPercentage = (val) => {
 }
 
 export const validPhoneNumber = (val) => {
-
     if (!val) {
         return true;
     }
 
-    const length = (val.match(/[0-9]/g) || []).length
-    return length >= 10;
+    const numberCount = (val.match(/[0-9]/g) || []).length
+    const validCharCount = (val.match(/[ 0-9()+]/g) || []).length
+    return val.length === validCharCount && numberCount >= 10
 }
 
 export const notNegativeNumber = (val) => {


### PR DESCRIPTION
A seller was unable to apply for an opportunity due to an invalid phone number for their authorised representative.  It looks like this might be due to their number including a `-` character.  This pull request makes the phone number validators consistent across files in this repo and with what the API uses.

Addresses MAR-4172