### PR TITLE
Preserve white space when comparing summaries

### DIFF
--- a/apps/marketplace/components/Brief/SummaryComparison.js
+++ b/apps/marketplace/components/Brief/SummaryComparison.js
@@ -22,13 +22,13 @@ const SummaryComparison = props => {
           <AUheading level="2" size="xs">
             Previous summary:
           </AUheading>
-          <p>{previous}</p>
+          <p className={styles.whiteSpacePreWrap}>{previous}</p>
         </div>
         <div className={`col-md-6 ${localStyles.updated} ${previousSummaryIsLonger ? '' : styles.greyBorderLeft1}`}>
           <AUheading level="2" size="xs">
             Updated summary:
           </AUheading>
-          <p>{updated}</p>
+          <p className={styles.whiteSpacePreWrap}>{updated}</p>
         </div>
       </div>
       <div className={`row ${styles.hideDesktop}`}>
@@ -36,13 +36,13 @@ const SummaryComparison = props => {
           <AUheading level="2" size="md">
             Previous summary:
           </AUheading>
-          <p>{previous}</p>
+          <p className={styles.whiteSpacePreWrap}>{previous}</p>
         </div>
         <div className={`col-xs-12 ${localStyles.updated} ${styles.greyBorderTop1}`}>
           <AUheading level="2" size="md">
             Updated summary:
           </AUheading>
-          <p>{updated}</p>
+          <p className={styles.whiteSpacePreWrap}>{updated}</p>
         </div>
       </div>
       <div className={`row ${styles.marginTop2}`}>


### PR DESCRIPTION
### Before
<img width="1149" alt="Screen Shot 2020-05-13 at 2 55 41 pm" src="https://user-images.githubusercontent.com/2645932/81772752-fda70280-9529-11ea-8e6b-bc3b66bdbf88.png">

### After
<img width="1142" alt="Screen Shot 2020-05-13 at 2 56 41 pm" src="https://user-images.githubusercontent.com/2645932/81772769-08619780-952a-11ea-8c7c-5aab510213c1.png">
