### PR TITLE
Add edit live opportunity step to Overview

### DIFF
--- a/apps/marketplace/components/BuyerBriefFlow/Overview.js
+++ b/apps/marketplace/components/BuyerBriefFlow/Overview.js
@@ -190,6 +190,11 @@ class Overview extends Component {
                 </span>
               )}
             </li>
+            {brief.status === 'draft' && (
+              <li>
+                <span>Edit live opportunity</span>
+              </li>
+            )}
             {brief.status === 'live' && isPublished && (
               <li>
                 {hasPermission(isPartOfTeam, isTeamLead, teams, 'publish_opportunities') ? (

--- a/apps/marketplace/components/BuyerBriefFlow/Overview.js
+++ b/apps/marketplace/components/BuyerBriefFlow/Overview.js
@@ -214,6 +214,12 @@ class Overview extends Component {
                 </div>
               </li>
             )}
+            {brief.status === 'closed' && (
+              <li>
+                <Tick className={styles.tick} colour="#17788D" />
+                <span>Edit live opportunity</span>
+              </li>
+            )}
             <li>
               {this.answerSellerQuestionsRender(brief, isPublished, isClosed)}
               <div className={styles.stageStatus}>


### PR DESCRIPTION
This pull request adds a step to the Overview for draft and closed opportunities.

### Draft
<img width="1171" alt="Screen Shot 2020-05-15 at 2 35 27 pm" src="https://user-images.githubusercontent.com/2645932/82011828-7a1c1b80-96b9-11ea-9ef4-9008b18edd75.png">

### Closed
<img width="1167" alt="Screen Shot 2020-05-15 at 2 34 52 pm" src="https://user-images.githubusercontent.com/2645932/82011839-7e483900-96b9-11ea-92dd-c560c6576037.png">

Addresses MAR-4183