### PR TITLE
Make summary text area the same size for all types of opportunities

### DIFF
--- a/apps/marketplace/components/Brief/Edit/EditOpportunitySummary.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunitySummary.js
@@ -52,7 +52,8 @@ class EditOpportunitySummary extends Component {
     let limitWordsMessage = 'Your summary has exceeded the 200 word limit'
     let requiredMessage = 'You must add a summary of work to be done'
     let controlProps = {
-      limit: 200
+      limit: 200,
+      rows: '10'
     }
 
     if (brief.lot === 'specialist') {


### PR DESCRIPTION
This pull request increases the size of the text area used when editing summaries for non-specialist opportunities.

### Before
<img width="305" alt="Screen Shot 2020-05-18 at 11 58 15 am" src="https://user-images.githubusercontent.com/2645932/82167371-ed629f00-98fe-11ea-816c-8aa0f798720d.png">
<img width="1168" alt="Screen Shot 2020-05-18 at 11 57 52 am" src="https://user-images.githubusercontent.com/2645932/82167377-f0f62600-98fe-11ea-9c37-5a4c3e74b7c0.png">

### After
<img width="306" alt="Screen Shot 2020-05-18 at 11 56 59 am" src="https://user-images.githubusercontent.com/2645932/82167532-81cd0180-98ff-11ea-967e-be930435a734.png">
<img width="1169" alt="Screen Shot 2020-05-18 at 11 56 25 am" src="https://user-images.githubusercontent.com/2645932/82167521-7c6fb700-98ff-11ea-978c-8e0dd3d1d3c7.png">

Addresses MAR-4187