### PR TITLE
Check for null characters if value is a string

### DIFF
--- a/apps/shared/validators.js
+++ b/apps/shared/validators.js
@@ -187,7 +187,7 @@ export const validPriceRange = max => val =>
   required(val) && validPrice(val) && (parseFloat(val) > 0 && parseFloat(max.replace(/,/g, '')) >= parseFloat(val))
 
 export const validCharacters = val => {
-  if (!val) {
+  if (!val || typeof val !== 'string') {
     return true
   }
 

--- a/src/validators.js
+++ b/src/validators.js
@@ -200,7 +200,7 @@ export const onlyWholeNumbers = (val) => {
 }
 
 export const validCharacters = val => {
-  if (!val) {
+  if (!val || typeof val !== 'string') {
     return true
   }
 


### PR DESCRIPTION
When #953 was released, Rollbar started reporting `TypeError: match is not defined`.  I think this is because the `match` function was being called for values other than strings, like a seller's maximum daily rate. This pull request will skip the check if a string is not passed to the validator.