### PR TITLE
Update edit history styles

### DIFF
--- a/apps/marketplace/components/Brief/OpportunityHistory.js
+++ b/apps/marketplace/components/Brief/OpportunityHistory.js
@@ -41,7 +41,7 @@ const EditSummary = props => {
         Object.prototype.hasOwnProperty.call(edit, 'requirementsDocument')) && (
         <span className={`${styles.grey} ${styles.smallText}`}>{format(edit.editedAt, 'DD MMMM YYYY[,] h[:]mma')}</span>
       )}
-      <ul>
+      <ul className={localStyles.editSummaryList}>
         {Object.keys(edit).map(key => {
           if (key === 'title') {
             return (

--- a/apps/marketplace/components/Brief/OpportunityHistory.js
+++ b/apps/marketplace/components/Brief/OpportunityHistory.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import format from 'date-fns/format'
 import { Link } from 'react-router-dom'
 
-import AUheading from '@gov.au/headings/lib/js/react.js'
-
 import PageHeader from 'marketplace/components/PageHeader/PageHeader'
 import { rootPath } from 'marketplace/routes'
 
@@ -41,9 +39,7 @@ const EditSummary = props => {
         Object.prototype.hasOwnProperty.call(edit, 'attachments') ||
         Object.prototype.hasOwnProperty.call(edit, 'responseTemplate') ||
         Object.prototype.hasOwnProperty.call(edit, 'requirementsDocument')) && (
-        <AUheading level="2" size="xs">
-          {format(edit.editedAt, 'DD MMMM YYYY[,] h[:]mma')}
-        </AUheading>
+        <span className={`${styles.grey} ${styles.smallText}`}>{format(edit.editedAt, 'DD MMMM YYYY[,] h[:]mma')}</span>
       )}
       <ul>
         {Object.keys(edit).map(key => {

--- a/apps/marketplace/components/Brief/OpportunityHistory.scss
+++ b/apps/marketplace/components/Brief/OpportunityHistory.scss
@@ -4,3 +4,8 @@
     padding: 0;
   }
 }
+
+.editSummaryList {
+  margin-top: 0.5rem;
+  padding-left: 1.25rem;
+}

--- a/apps/marketplace/main.scss
+++ b/apps/marketplace/main.scss
@@ -21,6 +21,10 @@
   }
 }
 
+.grey {
+  color: #757575;
+}
+
 .greyBorderBottom1 {
   border-bottom: 1px solid #979797;
 }
@@ -183,6 +187,10 @@
 
 .paddingTop1 {
   padding-top: 1rem;
+}
+
+.smallText {
+  font-size: 0.875rem;
 }
 
 .verticalAlignTop {


### PR DESCRIPTION
This pull request adjusts the styles that affect the timestamp and list of edits on the history page.

### Incoming
<img width="676" alt="Screen Shot 2020-06-23 at 2 59 19 pm" src="https://user-images.githubusercontent.com/2645932/85362590-30e5a400-b562-11ea-963a-e7b8f8192d26.png">

### Current
<img width="699" alt="Screen Shot 2020-06-23 at 2 58 40 pm" src="https://user-images.githubusercontent.com/2645932/85362604-380cb200-b562-11ea-80ba-bbce83401e8d.png">

Addresses MAR-4242