### PR TITLE
Move link to remove sellers when editing on smaller screens

### DIFF
--- a/apps/marketplace/components/Brief/Edit/AddSellerActions.js
+++ b/apps/marketplace/components/Brief/Edit/AddSellerActions.js
@@ -3,26 +3,28 @@ import PropTypes from 'prop-types'
 
 import AUlinklist from '@gov.au/link-list/lib/js/react.js'
 
-import itemSelectStyles from 'marketplace/components/ItemSelect/SelectedItems.scss'
+import styles from './AddSellerActions.scss'
 
 const AddSellerActions = props => {
   const { id, onRemoveSellerClick } = props
 
   return (
-    <AUlinklist
-      className={itemSelectStyles.selectedItemActions}
-      inline
-      items={[
-        {
-          link: '#remove',
-          onClick: e => {
-            e.preventDefault()
-            onRemoveSellerClick(id)
-          },
-          text: 'Remove'
-        }
-      ]}
-    />
+    <div className={styles.selectedItemActionsContainer}>
+      <AUlinklist
+        className={`${styles.selectedItemActions}`}
+        inline
+        items={[
+          {
+            link: '#remove',
+            onClick: e => {
+              e.preventDefault()
+              onRemoveSellerClick(id)
+            },
+            text: 'Remove'
+          }
+        ]}
+      />
+    </div>
   )
 }
 

--- a/apps/marketplace/components/Brief/Edit/AddSellerActions.scss
+++ b/apps/marketplace/components/Brief/Edit/AddSellerActions.scss
@@ -1,0 +1,27 @@
+.selectedItemActionsContainer {
+    display: inline;
+
+    ul.selectedItemActions {
+        float: right;
+        padding: 0;
+
+        li {
+            border: 0;
+            margin: 0rem 0.25rem;
+            padding: 0;
+        }
+    }
+}
+
+@media (max-width: 575px) {
+    .selectedItemActionsContainer {
+        ul.selectedItemActions {
+            display: block;
+
+            li {
+                display: block;
+                margin: 0;
+            }
+        }
+    }
+}

--- a/apps/marketplace/components/ItemSelect/SelectedItems.js
+++ b/apps/marketplace/components/ItemSelect/SelectedItems.js
@@ -17,7 +17,7 @@ const SelectedItemsList = props => {
       </AUheading>
       <ul className={styles.selectedItemsList}>
         {sortedKeys.map(key => (
-          <li key={key}>
+          <li className={styles.selectedListItem} key={key}>
             <span>{selectedItems[key].name}</span>
             {React.cloneElement(actions, { id: key, ...selectedItems[key] })}
           </li>

--- a/apps/marketplace/components/ItemSelect/SelectedItems.scss
+++ b/apps/marketplace/components/ItemSelect/SelectedItems.scss
@@ -5,35 +5,12 @@
         list-style-type: none;
         padding-left: 0;
 
-        li {
+        li.selectedListItem {
             border-top: 1px solid gray;
             padding: 0.75rem 0;
 
             &:last-child {
                 border-bottom: 1px solid gray;
-            }
-        }
-
-        ul.selectedItemActions {
-            float: right;
-            padding: 0;
-
-            li {
-                border: 0;
-                margin: 0rem 0.25rem;
-                padding: 0;
-            }
-        }
-
-        @media (max-width: 575px) {
-            ul.selectedItemActions {
-                display: block;
-                float: none;
-
-                li {
-                    display: block;
-                    margin: 0;
-                }
             }
         }
     }

--- a/apps/marketplace/components/Teams/Flows/TeamLeadActions.js
+++ b/apps/marketplace/components/Teams/Flows/TeamLeadActions.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux'
 import AUlinklist from '@gov.au/link-list/lib/js/react.js'
 
 import commonStyles from './TeamStages.scss'
-import itemSelectStyles from '../../ItemSelect/SelectedItems.scss'
 
 const TeamLeadActions = props => {
   const { handleConvertToTeamMember, handleRemoveTeamLead, id, emailAddress, currentUserEmailAddress } = props
@@ -13,29 +12,31 @@ const TeamLeadActions = props => {
     return ''
   }
   return (
-    <AUlinklist
-      className={itemSelectStyles.selectedItemActions}
-      inline
-      items={[
-        {
-          link: '#change-to-member',
-          onClick: e => {
-            e.preventDefault()
-            handleConvertToTeamMember(id)
+    <div className={commonStyles.selectedItemActionsContainer}>
+      <AUlinklist
+        className={`${commonStyles.selectedItemActions}`}
+        inline
+        items={[
+          {
+            link: '#change-to-member',
+            onClick: e => {
+              e.preventDefault()
+              handleConvertToTeamMember(id)
+            },
+            text: 'Change to member'
           },
-          text: 'Change to member'
-        },
-        {
-          className: commonStyles.removeLink,
-          link: '#remove',
-          onClick: e => {
-            e.preventDefault()
-            handleRemoveTeamLead(id)
-          },
-          text: 'Remove'
-        }
-      ]}
-    />
+          {
+            className: commonStyles.removeLink,
+            link: '#remove',
+            onClick: e => {
+              e.preventDefault()
+              handleRemoveTeamLead(id)
+            },
+            text: 'Remove'
+          }
+        ]}
+      />
+    </div>
   )
 }
 

--- a/apps/marketplace/components/Teams/Flows/TeamMemberActions.js
+++ b/apps/marketplace/components/Teams/Flows/TeamMemberActions.js
@@ -3,35 +3,36 @@ import React from 'react'
 import AUlinklist from '@gov.au/link-list/lib/js/react.js'
 
 import commonStyles from './TeamStages.scss'
-import itemSelectStyles from '../../ItemSelect/SelectedItems.scss'
 
 const TeamMemberActions = props => {
   const { handleConvertToTeamLead, handleRemoveTeamMember, id } = props
 
   return (
-    <AUlinklist
-      className={itemSelectStyles.selectedItemActions}
-      inline
-      items={[
-        {
-          link: '#change-to-lead',
-          onClick: e => {
-            e.preventDefault()
-            handleConvertToTeamLead(id)
+    <div className={commonStyles.selectedItemActionsContainer}>
+      <AUlinklist
+        className={`${commonStyles.selectedItemActions}`}
+        inline
+        items={[
+          {
+            link: '#change-to-lead',
+            onClick: e => {
+              e.preventDefault()
+              handleConvertToTeamLead(id)
+            },
+            text: 'Change to lead'
           },
-          text: 'Change to lead'
-        },
-        {
-          className: commonStyles.removeLink,
-          link: '#remove',
-          onClick: e => {
-            e.preventDefault()
-            handleRemoveTeamMember(id)
-          },
-          text: 'Remove'
-        }
-      ]}
-    />
+          {
+            className: commonStyles.removeLink,
+            link: '#remove',
+            onClick: e => {
+              e.preventDefault()
+              handleRemoveTeamMember(id)
+            },
+            text: 'Remove'
+          }
+        ]}
+      />
+    </div>
   )
 }
 

--- a/apps/marketplace/components/Teams/Flows/TeamStages.scss
+++ b/apps/marketplace/components/Teams/Flows/TeamStages.scss
@@ -43,3 +43,30 @@ a.removeLink {
         padding: 1rem 0.25rem;
     }
 }
+
+.selectedItemActionsContainer {
+    display: inline;
+
+    ul.selectedItemActions {
+        float: right;
+        padding: 0;
+
+        li {
+            border: 0;
+            margin: 0rem 0.25rem;
+            padding: 0;
+        }
+    }
+
+    @media (max-width: 575px) {
+        ul.selectedItemActions {
+            display: block;
+            float: none;
+
+            li {
+                display: block;
+                margin: 0;
+            }
+        }
+    }
+}

--- a/apps/marketplace/components/Teams/Flows/TeamStages.scss
+++ b/apps/marketplace/components/Teams/Flows/TeamStages.scss
@@ -45,10 +45,9 @@ a.removeLink {
 }
 
 .selectedItemActionsContainer {
-    display: inline;
+    float: right;
 
     ul.selectedItemActions {
-        float: right;
         padding: 0;
 
         li {
@@ -57,8 +56,13 @@ a.removeLink {
             padding: 0;
         }
     }
+}
 
-    @media (max-width: 575px) {
+@media (max-width: 575px) {
+    .selectedItemActionsContainer {
+        display: inline;
+        float: none;
+
         ul.selectedItemActions {
             display: block;
             float: none;


### PR DESCRIPTION
This pull request supports separate styles for selected items that are associated with the ItemSelect component.

### Incoming
<img width="309" alt="Screen Shot 2020-06-24 at 10 16 25 am" src="https://user-images.githubusercontent.com/2645932/85480725-db61d380-b603-11ea-8f27-050509701d8e.png">

### Current
<img width="307" alt="Screen Shot 2020-06-24 at 10 16 57 am" src="https://user-images.githubusercontent.com/2645932/85480751-e0268780-b603-11ea-81ce-6fe5e78dc7bf.png">

Addresses MAR-4162 