### PR TITLE
Show appropriate edit history content

### DIFF
--- a/apps/marketplace/actions/briefActions.js
+++ b/apps/marketplace/actions/briefActions.js
@@ -592,6 +592,7 @@ export const applyEditsToOpportunity = (briefId, data) => (dispatch, getState) =
 export const handleLoadOpportunityHistorySuccess = response => ({
   type: LOAD_OPPORTUNITY_EDIT_HISTORY_SUCCESS,
   brief: response.data.brief,
+  canRespond: response.data.can_respond,
   edits: response.data.edits
 })
 

--- a/apps/marketplace/components/Brief/OpportunityHistory.js
+++ b/apps/marketplace/components/Brief/OpportunityHistory.js
@@ -88,18 +88,28 @@ const allEditDetailsRemoved = edit =>
 
 const OpportunityHistory = props => {
   window.scrollTo(0, 0)
-  const { brief, edits } = props
+  const { brief, canRespond, edits, loggedIn, userType } = props
+  const showSignedInOrInvitedMessage = !loggedIn || (loggedIn && userType === 'supplier' && !canRespond)
+
+  const showNoChangesMessage =
+    loggedIn &&
+    (['admin', 'buyer'].includes(userType) || (userType === 'supplier' && canRespond)) &&
+    (edits.length === 0 || edits.every(allEditDetailsRemoved))
+
+  const showEdits =
+    loggedIn &&
+    (['admin', 'buyer'].includes(userType) || (userType === 'supplier' && canRespond)) &&
+    edits.length > 0 &&
+    !edits.every(allEditDetailsRemoved)
 
   return (
     <React.Fragment>
       <PageHeader actions={[]} organisation={`${brief.title} (${brief.id})`} title="History of updates" />
-      {edits.length > 0 &&
-        !edits.every(allEditDetailsRemoved) &&
-        edits.map(edit => <EditSummary edit={edit} key={edit.editedAt} />)}
-      {edits.length > 0 && edits.every(allEditDetailsRemoved) && (
+      {showSignedInOrInvitedMessage && (
         <p>You must be signed in as a buyer or invited seller to view the history of updates.</p>
       )}
-      {edits.length === 0 && <p>No changes have been made to this opportunity.</p>}
+      {showNoChangesMessage && <p>No changes have been made to this opportunity.</p>}
+      {showEdits && edits.map(edit => <EditSummary edit={edit} key={edit.editedAt} />)}
       <div className={styles.marginTop2}>
         <a href={`${rootPath}/${brief.framework}/opportunities/${brief.id}`}>Return to opportunity</a>
       </div>
@@ -118,11 +128,14 @@ OpportunityHistory.propTypes = {
     id: PropTypes.number.isRequired,
     title: PropTypes.string.isRequired
   }).isRequired,
+  canRespond: PropTypes.bool.isRequired,
   edits: PropTypes.arrayOf(
     PropTypes.shape({
       editedAt: PropTypes.string
     })
-  )
+  ),
+  loggedIn: PropTypes.bool.isRequired,
+  userType: PropTypes.string.isRequired
 }
 
 export default OpportunityHistory

--- a/apps/marketplace/pages/OpportunityHistoryPage.js
+++ b/apps/marketplace/pages/OpportunityHistoryPage.js
@@ -42,7 +42,7 @@ class OpportunityHistoryPage extends Component {
   }
 
   render = () => {
-    const { brief, edits, errorMessage } = this.props
+    const { brief, edits, errorMessage, loggedIn, userType } = this.props
     const { dataLoaded, loading } = this.state
 
     let hasFocused = false
@@ -85,7 +85,12 @@ class OpportunityHistoryPage extends Component {
                   />
                 )}
               />
-              <Route path="/" render={() => <OpportunityHistory brief={brief} edits={edits} />} />
+              <Route
+                path="/"
+                render={() => (
+                  <OpportunityHistory brief={brief} edits={edits} loggedIn={loggedIn} userType={userType} />
+                )}
+              />
             </Switch>
           </div>
         </BrowserRouter>
@@ -99,7 +104,9 @@ class OpportunityHistoryPage extends Component {
 const mapResetStateToProps = state => ({
   brief: state.brief.brief,
   edits: state.brief.edits,
-  errorMessage: state.app.errorMessage
+  errorMessage: state.app.errorMessage,
+  loggedIn: state.app.loggedIn,
+  userType: state.app.userType
 })
 
 const mapResetDispatchToProps = dispatch => ({

--- a/apps/marketplace/pages/OpportunityHistoryPage.js
+++ b/apps/marketplace/pages/OpportunityHistoryPage.js
@@ -42,7 +42,7 @@ class OpportunityHistoryPage extends Component {
   }
 
   render = () => {
-    const { brief, edits, errorMessage, loggedIn, userType } = this.props
+    const { brief, canRespond, edits, errorMessage, loggedIn, userType } = this.props
     const { dataLoaded, loading } = this.state
 
     let hasFocused = false
@@ -88,7 +88,13 @@ class OpportunityHistoryPage extends Component {
               <Route
                 path="/"
                 render={() => (
-                  <OpportunityHistory brief={brief} edits={edits} loggedIn={loggedIn} userType={userType} />
+                  <OpportunityHistory
+                    brief={brief}
+                    canRespond={canRespond}
+                    edits={edits}
+                    loggedIn={loggedIn}
+                    userType={userType}
+                  />
                 )}
               />
             </Switch>
@@ -103,6 +109,7 @@ class OpportunityHistoryPage extends Component {
 
 const mapResetStateToProps = state => ({
   brief: state.brief.brief,
+  canRespond: state.brief.canRespond,
   edits: state.brief.edits,
   errorMessage: state.app.errorMessage,
   loggedIn: state.app.loggedIn,

--- a/apps/marketplace/reducers/briefReducers.js
+++ b/apps/marketplace/reducers/briefReducers.js
@@ -215,6 +215,7 @@ const briefReducer = (state = defaultBriefState, action) => {
       return {
         ...state,
         brief: action.brief,
+        canRespond: action.canRespond,
         edits: action.edits
       }
 


### PR DESCRIPTION
This pull request is related to a bug in the API where invited sellers were being removed before the function call to check if only sellers were edited.  This meant that users would be shown the page alert on the opportunity's page notifying them that edits had been made but there would be no edit history to display if only sellers had been edited.

Additional logic has been added to show the appropriate content based on the user's role, whether they're logged in and if they can respond to the opportunity.

Related to https://github.com/AusDTO/dto-digitalmarketplace-api/pull/771.

Addresses MAR-4275