### PR TITLE
Show opportunity documents and questions if seller can respond

### DIFF
--- a/apps/marketplace/components/Opportunity/Opportunity.js
+++ b/apps/marketplace/components/Opportunity/Opportunity.js
@@ -451,7 +451,7 @@ const Opportunity = props => {
               <span>{'Only invited sellers and other buyers can view attached documents. '}</span>
             </div>
           )}
-          {loggedIn && (isOpenToAll || canRespond || isInvited || isBuyer) && (
+          {loggedIn && (isBuyer || canRespond) && (
             <div className={isBriefOwner ? styles.additionalInfoOwner : styles.additionalInfo}>
               {(brief.requirementsDocument.length > 0 || brief.attachments.length > 0) && (
                 <ul>

--- a/apps/marketplace/components/Opportunity/Opportunity.js
+++ b/apps/marketplace/components/Opportunity/Opportunity.js
@@ -618,7 +618,7 @@ const Opportunity = props => {
               )}
             </React.Fragment>
           )}
-          {(isInvited || isBuyer) && (
+          {(isBuyer || canRespond) && (
             <QuestionAnswer
               questions={brief.clarificationQuestions}
               clarificationQuestionsAreClosed={brief.clarificationQuestionsAreClosed}

--- a/apps/marketplace/components/Opportunity/Opportunity.js
+++ b/apps/marketplace/components/Opportunity/Opportunity.js
@@ -623,7 +623,7 @@ const Opportunity = props => {
               questions={brief.clarificationQuestions}
               clarificationQuestionsAreClosed={brief.clarificationQuestionsAreClosed}
               briefId={brief.id}
-              showAskQuestionInfo={canRespond || isInvited}
+              showAskQuestionInfo={canRespond}
             />
           )}
         </div>


### PR DESCRIPTION
This pull request simplifies the logic to determine when documents and questions are shown on the opportunity page.  It's intended to prevent sellers from accessing documents or asking questions if they can't respond to an opportunity (by design) or because they're not assessed.

Relates to: https://github.com/AusDTO/dto-digitalmarketplace-api/pull/778

Addresses MAR-4243