### PR TITLE
Add brief ID to seller search request

### DIFF
--- a/apps/marketplace/actions/supplierActions.js
+++ b/apps/marketplace/actions/supplierActions.js
@@ -9,11 +9,12 @@ import { GENERAL_ERROR } from '../constants/messageConstants'
 import dmapi from '../services/apiClient'
 import { sendingRequest, setErrorMessage } from './appActions'
 
-export const findSuppliers = (keyword, category, all, codesToExclude = []) => {
+export const findSuppliers = (keyword, category, all, briefId, codesToExclude = []) => {
   const params = {
     keyword,
     category,
     all,
+    briefId,
     exclude: JSON.stringify(codesToExclude)
   }
   return dmapi({ url: `/suppliers/search`, params }).then(response => {

--- a/apps/marketplace/components/Brief/Edit/EditOpportunitySellers.js
+++ b/apps/marketplace/components/Brief/Edit/EditOpportunitySellers.js
@@ -114,7 +114,7 @@ class EditOpportunitySellers extends Component {
     this.setState({
       timeoutId: setTimeout(() => {
         if (this.state.sellerName && this.state.sellerName.length >= 2) {
-          findSuppliers(this.state.sellerName, brief.sellerCategory, false, Object.keys(brief.sellers))
+          findSuppliers(this.state.sellerName, brief.sellerCategory, false, brief.id, Object.keys(brief.sellers))
             .then(data => {
               this.setState({
                 searchResults: data.sellers

--- a/apps/marketplace/components/BuyerRFX/BuyerRFXSelectStage.js
+++ b/apps/marketplace/components/BuyerRFX/BuyerRFXSelectStage.js
@@ -83,6 +83,7 @@ export class BuyerRFXSelectStage extends Component {
           <div className="col-xs-12 col-sm-9">
             <div className={styles.selectSellers}>
               <SellerSelect
+                briefId={this.props[this.props.model].id}
                 label="Seller name"
                 description={
                   <span>

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
@@ -115,6 +115,7 @@ export class BuyerSpecialistSelectStage extends Component {
             {this.props[this.props.model].openTo === 'selected' && (
               <React.Fragment>
                 <SellerSelect
+                  briefId={this.props[this.props.model].id}
                   label="Seller name"
                   showSelected={false}
                   showSearchButton={false}

--- a/apps/marketplace/components/BuyerTraining/BuyerTrainingSelectStage.js
+++ b/apps/marketplace/components/BuyerTraining/BuyerTrainingSelectStage.js
@@ -92,6 +92,7 @@ export class BuyerTrainingSelectStage extends Component {
           <div className="col-xs-12 col-sm-9">
             <div className={styles.selectSellers}>
               <SellerSelect
+                briefId={this.props[model].id}
                 label="Seller name"
                 description={
                   <span>

--- a/apps/marketplace/components/SellerSelect/SellerSelect.js
+++ b/apps/marketplace/components/SellerSelect/SellerSelect.js
@@ -135,7 +135,9 @@ export class SellerSelect extends Component {
   }
 
   handleSearchChange(e) {
+    const { briefId } = this.props
     const keyword = e.target.value
+
     this.setState({
       inputValue: keyword,
       noResults: false
@@ -147,7 +149,7 @@ export class SellerSelect extends Component {
 
     timeoutHandle = setTimeout(() => {
       if (keyword && keyword.length >= this.props.minimumSearchChars && this.categoryIsValid()) {
-        findSuppliers(keyword, this.props.selectedCategory, this.props.allSuppliers ? 'true' : '')
+        findSuppliers(keyword, this.props.selectedCategory, this.props.allSuppliers ? 'true' : '', briefId)
           .then(data => {
             const noResults = !data.sellers.length > 0
             this.setState({
@@ -228,6 +230,7 @@ export class SellerSelect extends Component {
 }
 
 SellerSelect.defaultProps = {
+  briefId: null,
   id: 'seller-search',
   placeholder: '',
   label: '',
@@ -247,6 +250,7 @@ SellerSelect.defaultProps = {
 }
 
 SellerSelect.propTypes = {
+  briefId: PropTypes.number,
   id: PropTypes.string,
   placeholder: PropTypes.string,
   label: PropTypes.string,


### PR DESCRIPTION
This pull request adds the brief ID to the seller search request.  This is used to determine if recruiters can be invited to the opportunity.  Recruiters can only respond to specialist opportunities.

Relates to: https://github.com/AusDTO/dto-digitalmarketplace-api/pull/779

Addresses MAR-4309