### PR TITLE
Replace @digital.gov.au with @dta.gov.au

### DIFF
--- a/apps/marketplace/components/NotFound.js
+++ b/apps/marketplace/components/NotFound.js
@@ -14,10 +14,10 @@ const NotFound = () => (
         <p>
           If you can&#39;t find what you&#39;re looking for, email{' '}
           <a
-            href="mailto:marketplace@digital.gov.au?subject=Marketplace%20feedback"
-            title="Please send feedback to marketplace@digital.gov.au"
+            href="mailto:marketplace@dta.gov.au?subject=Marketplace%20feedback"
+            title="Please send feedback to marketplace@dta.gov.au"
           >
-            marketplace@digital.gov.au
+            marketplace@dta.gov.au
           </a>
         </p>
       </div>

--- a/apps/marketplace/constants/messageConstants.js
+++ b/apps/marketplace/constants/messageConstants.js
@@ -15,4 +15,4 @@ export const LOGIN_FAILED =
   "Make sure you've entered the right email address and password. Accounts are locked after 5 failed attempts."
 export const EMAIL_NOT_WHITELISTED =
   'Your email domain is not registered for use on Digital Marketplace. ' +
-  'Please request approval from marketplace@digital.gov.au'
+  'Please request approval from marketplace@dta.gov.au'

--- a/apps/shared/NotFound.js
+++ b/apps/shared/NotFound.js
@@ -16,10 +16,10 @@ const NotFound = () => (
           <p>
             If you can&#39;t find what you&#39;re looking for, email{' '}
             <a
-              href="mailto:marketplace@digital.gov.au?subject=Marketplace%20feedback"
-              title="Please send feedback to marketplace@digital.gov.au"
+              href="mailto:marketplace@dta.gov.au?subject=Marketplace%20feedback"
+              title="Please send feedback to marketplace@dta.gov.au"
             >
-              marketplace@digital.gov.au
+              marketplace@dta.gov.au
             </a>
           </p>
         </div>

--- a/apps/shared/SaveError.js
+++ b/apps/shared/SaveError.js
@@ -9,7 +9,7 @@ const SaveError = ({ error }) => (
       <div className="callout--warning" aria-describedby="validation-masthead-heading" tabIndex="-1" role="alert">
         <h4 id="validation-masthead-heading">We couldn't save your information.</h4>
         Check your internet connection and if there's still a problem email{' '}
-        <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>
+        <a href="mailto:marketplace@dta.gov.au">marketplace@dta.gov.au</a>
       </div>
     )}
   </div>

--- a/src/bundles/Collaborate/components/Code/Code.js
+++ b/src/bundles/Collaborate/components/Code/Code.js
@@ -44,7 +44,7 @@ class Code extends React.Component {
                             You can learn how to <a href="https://opensource.guide/" rel="external noopener noreferrer" target="_blank">launch
                             and grow your project</a> or contact us if you would like some help.<br/>
 
-                            <a href="mailto:marketplace@digital.gov.au?subject=Open source projects"
+                            <a href="mailto:marketplace@dta.gov.au?subject=Open source projects"
                                className="button">Get in touch</a>
                         </article>
                     </div>
@@ -97,7 +97,7 @@ class Code extends React.Component {
                             <h2 >What features will help your team? </h2>
                             <p>
                                 Let us know what you would like to see in the library<br/>
-                                <a href="mailto:marketplace@digital.gov.au?subject=Feedback"
+                                <a href="mailto:marketplace@dta.gov.au?subject=Feedback"
                                    className="button">Get in touch</a></p>
                         </article>
                     </div>

--- a/src/bundles/Collaborate/components/ProjectSubmitConfirmation/ProjectSubmitConfirmation.js
+++ b/src/bundles/Collaborate/components/ProjectSubmitConfirmation/ProjectSubmitConfirmation.js
@@ -11,7 +11,7 @@ class ProjectSubmitConfirmation extends React.Component {
             <section>
                 <h1 className="au-display-xl"><Icon value="complete-tick" size={30}/><span styleName="callout-heading">Thanks for adding your project!</span></h1>
                 <p>Your project will be added to the new collaboration area on the Marketplace in the coming weeks.<br/>
-                    If you have any questions or feedback, email us at <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>.</p>
+                    If you have any questions or feedback, email us at <a href="mailto:marketplace@dta.gov.au">marketplace@dta.gov.au</a>.</p>
             </section>
         )
     }

--- a/src/bundles/SellerRegistration/components/SignupForm/SignupForm.js
+++ b/src/bundles/SellerRegistration/components/SignupForm/SignupForm.js
@@ -291,7 +291,7 @@ class SignupForm extends BaseForm {
                 description={isBuyer
                 ? (
                     <span>If your email is different, request your account
-                  from <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>.</span>
+                  from <a href="mailto:marketplace@dta.gov.au">marketplace@dta.gov.au</a>.</span>
                 )
                 : (<br/>)}
                 validators={emailValidators}

--- a/src/shared/NotFound.js
+++ b/src/shared/NotFound.js
@@ -11,7 +11,7 @@ const NotFound = () => (
           Check you've entered the correct web address or start again on the <a href="/">Digital Marketplace homepage</a>.
         </p>
         <p>
-          If you can't find what you're looking for, email <a href="mailto:marketplace@digital.gov.au?subject=Marketplace%20feedback" title="Please send feedback to marketplace@digital.gov.au">marketplace@digital.gov.au</a>
+          If you can't find what you're looking for, email <a href="mailto:marketplace@dta.gov.au?subject=Marketplace%20feedback" title="Please send feedback to marketplace@dta.gov.au">marketplace@dta.gov.au</a>
         </p>
       </div>
     </div>

--- a/src/shared/SaveError.js
+++ b/src/shared/SaveError.js
@@ -6,7 +6,7 @@ const SaveError = ({error}) => (
 		{error && 
 		  <div className="callout--warning" aria-describedby="validation-masthead-heading" tabIndex="-1" role="alert">
 		    <h4 id="validation-masthead-heading">We couldn't save your information.</h4>
-		      Check your internet connection and if there's still a problem email <a href="mailto:marketplace@digital.gov.au">marketplace@digital.gov.au</a>
+		      Check your internet connection and if there's still a problem email <a href="mailto:marketplace@dta.gov.au">marketplace@dta.gov.au</a>
 		  </div>
 		 }
 	</div>

--- a/src/shared/SellerProfile/Body.js
+++ b/src/shared/SellerProfile/Body.js
@@ -336,7 +336,7 @@ const Body = (props) => {
             </tbody>
           </table>
 
-          <p className="callout">Please <a href="mailto:marketplace@digital.gov.au">contact us</a> to view seller documents</p>
+          <p className="callout">Please <a href="mailto:marketplace@dta.gov.au">contact us</a> to view seller documents</p>
 
         </Row>
       </div>


### PR DESCRIPTION
This pull request replaces references to the `marketplace@digital.gov.au` email address with `marketplace@dta.gov.au` to match the address that is configured with Zendesk.