### PR TITLE
Update referee label and description 

### DIFF
--- a/apps/marketplace/components/SellerAssessment/SellerAssessmentEvidenceStage.js
+++ b/apps/marketplace/components/SellerAssessment/SellerAssessmentEvidenceStage.js
@@ -331,7 +331,7 @@ class SellerAssessmentEvidenceStage extends Component {
                   model={`${this.props.model}.evidence[${criteriaId}].refereeName`}
                   defaultValue={this.props[this.props.model].evidence[criteriaId].refereeName}
                   disabled={index !== 0 && this.isCriteriaDetailsDisabled(criteriaId)}
-                  label="Referee's full name"
+                  label="Client referee's full name"
                   description="The referee must be an employee of the client who can verify your involvement in the project."
                   name={`referee_name_${criteriaId}`}
                   id={`referee_name_${criteriaId}`}

--- a/apps/marketplace/components/SellerAssessment/SellerAssessmentEvidenceStage.js
+++ b/apps/marketplace/components/SellerAssessment/SellerAssessmentEvidenceStage.js
@@ -332,7 +332,7 @@ class SellerAssessmentEvidenceStage extends Component {
                   defaultValue={this.props[this.props.model].evidence[criteriaId].refereeName}
                   disabled={index !== 0 && this.isCriteriaDetailsDisabled(criteriaId)}
                   label="Referee's full name"
-                  description="We may contact your referee to confirm your involvement in the project."
+                  description="The referee must be an employee of the client who can verify your involvement in the project."
                   name={`referee_name_${criteriaId}`}
                   id={`referee_name_${criteriaId}`}
                   htmlFor={`referee_name_${criteriaId}`}


### PR DESCRIPTION
This pull request updates the content used for the label and description of the referee field that sellers must complete when submitting evidence for a category assessment.

Addresses MAR-4329