### PR TITLE
Make intro content consistent across opportunities

### DIFF
--- a/apps/marketplace/components/BuyerATM/BuyerATMIntroductionStage.js
+++ b/apps/marketplace/components/BuyerATM/BuyerATMIntroductionStage.js
@@ -21,9 +21,9 @@ const BuyerATMIntroductionStage = props => (
     </AUheadings>
     <ul>
       <li>
-        Download the{' '}
+        You can{' '}
         <a href="/api/2/r/ask-market-questions-template.docx" rel="noopener noreferrer" target="_blank">
-          questions template (DOC 52KB)
+          download the list of questions (DOCX 87KB)
         </a>{' '}
         to prepare offline before publishing.
       </li>

--- a/apps/marketplace/components/BuyerRFX/BuyerRFXIntroductionStage.js
+++ b/apps/marketplace/components/BuyerRFX/BuyerRFXIntroductionStage.js
@@ -15,9 +15,9 @@ const BuyerRFXIntroductionStage = props => (
       <li>
         You can{' '}
         <a href="/api/2/r/seek-proposals-and-quotes-questions-template.docx" rel="noopener noreferrer" target="_blank">
-          download the list of questions (XLSX 84 KB)
+          download the list of questions (DOCX 91KB)
         </a>{' '}
-        to prepare your request offline before publishing.
+        to prepare offline before publishing.
       </li>
       <li>
         Read the{' '}

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistIntroductionStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistIntroductionStage.js
@@ -14,9 +14,9 @@ const BuyerSpecialistIntroductionStage = props => (
     </AUheadings>
     <ul>
       <li>
-        Download the{' '}
+        You can{' '}
         <a href="/api/2/r/specialist-questions-template.docx" rel="noopener noreferrer" target="_blank">
-          questions template (xlsx 113KB)
+          download the list of questions (DOCX 92KB)
         </a>{' '}
         to prepare offline before publishing.
       </li>

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistStages.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistStages.js
@@ -32,7 +32,7 @@ const BuyerSpecialistStages = [
   },
   {
     slug: 'criteria',
-    title: 'Selection criteria',
+    title: 'Evaluation criteria',
     component: BuyerEvaluationCriteriaStage,
     isDone: evaluationDone
   },

--- a/apps/marketplace/components/BuyerTraining/BuyerTrainingIntroductionStage.js
+++ b/apps/marketplace/components/BuyerTraining/BuyerTrainingIntroductionStage.js
@@ -37,13 +37,13 @@ const BuyerTrainingIntroductionStage = props => (
       <li>
         Download the{' '}
         <a href="/api/2/r/training-draft-questions" rel="noopener noreferrer" target="_blank">
-          draft questions
+          list of questions (DOCX 68KB)
         </a>{' '}
         and{' '}
         <a href="/api/2/r/training-requirement-documents" rel="noopener noreferrer" target="_blank">
           requirement documents
         </a>{' '}
-        to prepare your request offline before publishing.
+        to prepare offline before publishing.
       </li>
       <li>
         Read the{' '}


### PR DESCRIPTION
This pull request: 

1. Makes the content consistent across the `Introduction` stage of all opportunities
2. Updates the file size for the new question templates that will be uploaded to Zendesk
3. Updates the stage title to match the page heading for the specialist `Evaluation criteria` stage