### PR TITLE
HM-3233: Clear CSRF token when invalid

### DIFF
--- a/apps/marketplace/actions/appActions.js
+++ b/apps/marketplace/actions/appActions.js
@@ -86,6 +86,7 @@ export const login = data => (dispatch, getState) => {
   }).then(response => {
     if (response.error) {
       if (response.data && response.data.message && response.data.message.toLowerCase().includes('invalid csrf')) {
+        dispatch(setAuthState({ csrfToken: '' }))
         dispatch(setErrorMessage(INVALID_CSRF))
       } else {
         dispatch(setErrorMessage(LOGIN_FAILED))

--- a/apps/marketplace/actions/appActions.js
+++ b/apps/marketplace/actions/appActions.js
@@ -86,7 +86,7 @@ export const login = data => (dispatch, getState) => {
   }).then(response => {
     if (response.error) {
       if (response.data && response.data.message && response.data.message.toLowerCase().includes('invalid csrf')) {
-        dispatch(setAuthState({ csrfToken: '' }))
+        dispatch(setAuthState({ isAuthenticated: false, userType: '', csrfToken: '' }))
         dispatch(setErrorMessage(INVALID_CSRF))
       } else {
         dispatch(setErrorMessage(LOGIN_FAILED))

--- a/apps/marketplace/actions/resetPasswordActions.js
+++ b/apps/marketplace/actions/resetPasswordActions.js
@@ -26,7 +26,7 @@ export const sendResetPasswordEmail = values => (dispatch, getState) => {
   }).then(response => {
     if (response.error) {
       if (response.data && response.data.message && response.data.message.toLowerCase().includes('invalid csrf')) {
-        dispatch(setAuthState({ csrfToken: '' }))
+        dispatch(setAuthState({ isAuthenticated: false, userType: '', csrfToken: '' }))
         dispatch(setErrorMessage(INVALID_CSRF))
       } else {
         dispatch(setErrorMessage(UNABLE_TO_SEND))

--- a/apps/marketplace/actions/resetPasswordActions.js
+++ b/apps/marketplace/actions/resetPasswordActions.js
@@ -7,7 +7,7 @@ import {
 import { INVALID_CSRF, UNABLE_TO_RESET, UNABLE_TO_SEND } from '../constants/messageConstants'
 
 import dmapi from '../services/apiClient'
-import { logout, sendingRequest, setErrorMessage } from './appActions'
+import { logout, sendingRequest, setAuthState, setErrorMessage } from './appActions'
 
 export const handleResetPasswordSuccess = () => ({ type: RESET_PASSWORD_EMAIL_SUCCESS })
 const initialiseResetPasswordEmail = () => ({ type: RESET_PASSWORD_EMAIL_INITIAL })
@@ -26,6 +26,7 @@ export const sendResetPasswordEmail = values => (dispatch, getState) => {
   }).then(response => {
     if (response.error) {
       if (response.data && response.data.message && response.data.message.toLowerCase().includes('invalid csrf')) {
+        dispatch(setAuthState({ csrfToken: '' }))
         dispatch(setErrorMessage(INVALID_CSRF))
       } else {
         dispatch(setErrorMessage(UNABLE_TO_SEND))


### PR DESCRIPTION
This pull request clears the CSRF token if it's invalid after a login or password reset attempt.