### PR TITLE
HM-3487: Use buildpack with Node.js v10

### DIFF
--- a/manifest-prod.yml
+++ b/manifest-prod.yml
@@ -1,5 +1,5 @@
 command:  ./scripts/cf_run_app.sh
-buildpack: nodejs_buildpack
+buildpack: nodejs10_buildpack
 memory: 256M
 disk_quota: 512M
 instances: 2

--- a/manifest.alpha.yml
+++ b/manifest.alpha.yml
@@ -1,7 +1,7 @@
 applications:
 - name: dm-alpha-frontend
   command:  ./scripts/cf_run_app.sh
-  buildpack: nodejs_buildpack
+  buildpack: nodejs10_buildpack
   memory: 256M
   disk_quota: 512M
   instances: 1

--- a/manifest.pc.yml
+++ b/manifest.pc.yml
@@ -1,7 +1,7 @@
 applications:
 - name: dm-pc-frontend
   command:  ./scripts/cf_run_app.sh
-  buildpack: nodejs_buildpack
+  buildpack: nodejs10_buildpack
   memory: 256M
   disk_quota: 512M
   instances: 1

--- a/manifest.rc.yml
+++ b/manifest.rc.yml
@@ -1,7 +1,7 @@
 applications:
 - name: dm-rc-frontend
   command:  ./scripts/cf_run_app.sh
-  buildpack: nodejs_buildpack
+  buildpack: nodejs10_buildpack
   memory: 256M
   disk_quota: 512M
   instances: 1

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 command:  ./scripts/cf_run_app.sh
-buildpack: nodejs_buildpack
+buildpack: nodejs10_buildpack
 memory: 256M
 disk_quota: 512M
 instances: 1


### PR DESCRIPTION
The following error was encountered during deployment of the app:

> Unable to install node: no match found for 10.x in [12.22.5 12.22.6 14.17.5 14.17.6 15.13.0 15.14.0 16.7.0 16.8.0]

This is most likely caused by an update to the Cloud Foundry buildpack which dropped support for version 10.x.