### PR TITLE
HM-2845: Hide empty desirable criteria

### DIFF
--- a/apps/marketplace/components/Brief/BriefSpecialistResponseForm2.js
+++ b/apps/marketplace/components/Brief/BriefSpecialistResponseForm2.js
@@ -312,25 +312,27 @@ const BriefSpecialistResponseForm2 = ({
                     description={brief.includeWeightingsEssential ? `Weighting: ${requirement.weighting}%` : ''}
                   />
                 ))}
-              {brief.niceToHaveRequirements && brief.niceToHaveRequirements.length > 0 && (
-                <React.Fragment>
-                  <h2 className="au-display-lg">Desirable selection criteria</h2>
-                  {brief.niceToHaveRequirements.map((requirement, i) => (
-                    <Textarea
-                      key={requirement.criteria}
-                      model={`${model}.niceToHaveRequirements['${escapeQuote(requirement.criteria)}']`}
-                      name={`niceToHaveRequirement.${requirement.criteria}`}
-                      id={`niceToHaveRequirement.${i}`}
-                      controlProps={{
-                        limit: 500,
-                        rows: '8'
-                      }}
-                      label={`${requirement.criteria} (optional)`}
-                      description={brief.includeWeightingsNiceToHave ? `Weighting: ${requirement.weighting}%` : ''}
-                    />
-                  ))}
-                </React.Fragment>
-              )}
+              {brief.niceToHaveRequirements &&
+                brief.niceToHaveRequirements.length > 0 &&
+                brief.niceToHaveRequirements.some(criterion => criterion.criteria !== '') && (
+                  <React.Fragment>
+                    <h2 className="au-display-lg">Desirable selection criteria</h2>
+                    {brief.niceToHaveRequirements.map((requirement, i) => (
+                      <Textarea
+                        key={requirement.criteria}
+                        model={`${model}.niceToHaveRequirements['${escapeQuote(requirement.criteria)}']`}
+                        name={`niceToHaveRequirement.${requirement.criteria}`}
+                        id={`niceToHaveRequirement.${i}`}
+                        controlProps={{
+                          limit: 500,
+                          rows: '8'
+                        }}
+                        label={`${requirement.criteria} (optional)`}
+                        description={brief.includeWeightingsNiceToHave ? `Weighting: ${requirement.weighting}%` : ''}
+                      />
+                    ))}
+                  </React.Fragment>
+                )}
               <AUheadings level="2" size="sm">
                 {showResumeField(briefResponseForm, briefResponseStatus) ? 'Other documents (optional)' : 'Attachments'}
               </AUheadings>

--- a/apps/marketplace/components/Brief/BriefSpecialistResponseForm2.js
+++ b/apps/marketplace/components/Brief/BriefSpecialistResponseForm2.js
@@ -317,20 +317,25 @@ const BriefSpecialistResponseForm2 = ({
                 brief.niceToHaveRequirements.some(criterion => criterion.criteria !== '') && (
                   <React.Fragment>
                     <h2 className="au-display-lg">Desirable selection criteria</h2>
-                    {brief.niceToHaveRequirements.map((requirement, i) => (
-                      <Textarea
-                        key={requirement.criteria}
-                        model={`${model}.niceToHaveRequirements['${escapeQuote(requirement.criteria)}']`}
-                        name={`niceToHaveRequirement.${requirement.criteria}`}
-                        id={`niceToHaveRequirement.${i}`}
-                        controlProps={{
-                          limit: 500,
-                          rows: '8'
-                        }}
-                        label={`${requirement.criteria} (optional)`}
-                        description={brief.includeWeightingsNiceToHave ? `Weighting: ${requirement.weighting}%` : ''}
-                      />
-                    ))}
+                    {brief.niceToHaveRequirements.map(
+                      (requirement, i) =>
+                        requirement.criteria && (
+                          <Textarea
+                            key={requirement.criteria}
+                            model={`${model}.niceToHaveRequirements['${escapeQuote(requirement.criteria)}']`}
+                            name={`niceToHaveRequirement.${requirement.criteria}`}
+                            id={`niceToHaveRequirement.${i}`}
+                            controlProps={{
+                              limit: 500,
+                              rows: '8'
+                            }}
+                            label={`${requirement.criteria} (optional)`}
+                            description={
+                              brief.includeWeightingsNiceToHave ? `Weighting: ${requirement.weighting}%` : ''
+                            }
+                          />
+                        )
+                    )}
                   </React.Fragment>
                 )}
               <AUheadings level="2" size="sm">


### PR DESCRIPTION
This pull request hides the desirable criteria section in the seller response flow if no desirable criteria exist.  It also renders textfields only if the criterion has been defined (ie. is not an empty string).