### PR TITLE
HM-3650: Add colours to insights

### DIFF
--- a/apps/marketplace/components/Insights/NumberOfSellersPerCategory.js
+++ b/apps/marketplace/components/Insights/NumberOfSellersPerCategory.js
@@ -38,7 +38,9 @@ export class NumberOfSellersPerCategory extends Component {
               '#FEAB85',
               '#A15E9A',
               '#27809B',
-              '#DFBFBF'
+              '#DFBFBF',
+              '#00B8A9',
+              '#85000B'
             ]
           }
         ],

--- a/apps/marketplace/components/Insights/WhoIsBuying.js
+++ b/apps/marketplace/components/Insights/WhoIsBuying.js
@@ -24,7 +24,20 @@ export class WhoIsBuying extends Component {
         datasets: [
           {
             data: counts.map(a => a.count),
-            backgroundColor: ['#8537BF', '#FF89C4', '#37AFF7', '#F2A16A', '#6EA846']
+            backgroundColor: [
+              '#8537BF',
+              '#FF89C4',
+              '#37AFF7',
+              '#F2A16A',
+              '#6EA846',
+              '#BF4137',
+              '#BF8537',
+              '#88BE63',
+              '#EE833B',
+              '#0A9AF1',
+              '#FF56AB',
+              '#9D5ACF'
+            ]
           }
         ],
         labels: counts.map(a => a.name)

--- a/apps/marketplace/components/Insights/WhoIsBuying.js
+++ b/apps/marketplace/components/Insights/WhoIsBuying.js
@@ -70,7 +70,7 @@ export class WhoIsBuying extends Component {
         </div>
         <div className="row">
           <div className={`col-xs-12 col-md-7 ${styles.marginBottom1}`}>
-            <div className={insightStyles['chart-md-height-2x']}>
+            <div className={insightStyles['chart-md-height-10x']}>
               {/* eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role */}
               <canvas ref={this.chartRef} aria-label="Who is buying?" role="img" />
             </div>

--- a/apps/marketplace/components/Insights/WhoIsBuying.js
+++ b/apps/marketplace/components/Insights/WhoIsBuying.js
@@ -40,7 +40,7 @@ export class WhoIsBuying extends Component {
             ]
           }
         ],
-        labels: counts.map(a => a.name)
+        labels: counts.map(a => `${a.name} (${a.count})`)
       },
       options: {
         plugins: {


### PR DESCRIPTION
This pull request adds more colours to the `Who is buying?` and `Number of sellers per category` charts to account for expanded data.  The height of the `Who is buying?` chart has been increased to improve how it renders on smaller screens.

## Current
<img width="1159" alt="Screen Shot 2021-11-11 at 11 03 58 am" src="https://user-images.githubusercontent.com/2645932/141213107-86c6a846-a4cd-48e1-8197-f1ef440079d3.png">
<img width="628" alt="Screen Shot 2021-11-11 at 11 03 36 am" src="https://user-images.githubusercontent.com/2645932/141213105-d58873c5-d124-4b0f-b08f-8e195e12d88b.png">

## Incoming
<img width="1157" alt="Screen Shot 2021-11-11 at 11 04 35 am" src="https://user-images.githubusercontent.com/2645932/141213092-2e1cb7e2-fe5c-4a0c-9935-d31abddb48f8.png">
<img width="650" alt="Screen Shot 2021-11-11 at 11 04 22 am" src="https://user-images.githubusercontent.com/2645932/141213113-ea27dfb3-0132-49d6-8077-58eb1b3630f4.png">
