### PR TITLE
HM-4374: Reorder components on Who Can Respond stage

### DIFF
--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
@@ -58,8 +58,6 @@ export class BuyerSpecialistSelectStage extends Component {
   handleSellerCategorySelect(category) {
     if (category !== this.props[this.props.model].sellerCategory) {
       this.props.updateSelectedSellerCategory(category)
-      //this.props.resetOpenTo()
-      //this.props.resetSelectedSellers()
     }
   }
 
@@ -127,7 +125,6 @@ export class BuyerSpecialistSelectStage extends Component {
                 }
               ]}
               messages={{}}
-              onChange={() => this.props.resetSelectedSellers()}
             />
           </div>
           {this.props[this.props.model].openTo === 'all' && (
@@ -211,9 +208,7 @@ const mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = (dispatch, props) => ({
   countSellers: () => dispatch(countLabourHireSellers()),
-  resetSelectedSellers: () => dispatch(actions.change(`${props.model}.sellers`, {})),
   updateSelectedSellers: sellers => dispatch(actions.change(`${props.model}.sellers`, sellers)),
-  resetOpenTo: () => dispatch(actions.change(`${props.model}.openTo`, '')),
   updateSelectedSellerCategory: category => dispatch(actions.change(`${props.model}.sellerCategory`, category))
 })
 

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
@@ -128,7 +128,7 @@ export class BuyerSpecialistSelectStage extends Component {
             />
           </div>
           {this.props[this.props.model].openTo === 'all' && (
-            <AUpageAlert as="warning">
+            <AUpageAlert as="warning" className={mainStyles.marginBottom3}>
               <AUheading level="2" size="lg">
                 You are about to invite{' '}
                 {this.state.totalLabourHireSellers >= 1 ? this.state.totalLabourHireSellers : 'all'} seller

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
@@ -135,12 +135,12 @@ export class BuyerSpecialistSelectStage extends Component {
             </AUheading>
             <div className={mainStyles.marginTop1}>
               <p>
-                You will need to reply to all seller questions, evaluate all quotes and debrief all unsuccessful
-                sellers (where requested).
+                You will need to reply to all seller questions, evaluate all quotes and debrief all unsuccessful sellers
+                (where requested).
               </p>
               <p>
-                You should only invite all sellers if there is a business need for this approach. If you have
-                questions, please{' '}
+                You should only invite all sellers if there is a business need for this approach. If you have questions,
+                please{' '}
                 <a href="/contact-us" rel="noopener noreferrer" target="_blank">
                   contact us
                 </a>

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
@@ -108,81 +108,79 @@ export class BuyerSpecialistSelectStage extends Component {
           }}
         />
         <div>
-          <div>
-            <RadioList
-              id="openTo"
-              label="Accept responses from:"
-              name="openTo"
-              model={`${this.props.model}.openTo`}
-              options={[
-                {
-                  label: 'Any seller that provides ICT Labour Hire',
-                  value: 'all'
-                },
-                {
-                  label: 'Specific ICT Labour Hire sellers',
-                  value: 'selected'
-                }
-              ]}
-              messages={{}}
-            />
-          </div>
-          {this.props[this.props.model].openTo === 'all' && (
-            <AUpageAlert as="warning" className={mainStyles.marginBottom3}>
-              <AUheading level="2" size="lg">
-                You are about to invite{' '}
-                {this.state.totalLabourHireSellers >= 1 ? this.state.totalLabourHireSellers : 'all'} seller
-                {this.state.totalLabourHireSellers === 1 ? '' : 's'}.
-              </AUheading>
-              <div className={mainStyles.marginTop1}>
-                <p>
-                  You will need to reply to all seller questions, evaluate all quotes and debrief all unsuccessful
-                  sellers (where requested).
-                </p>
-                <p>
-                  You should only invite all sellers if there is a business need for this approach. If you have
-                  questions, please{' '}
-                  <a href="/contact-us" rel="noopener noreferrer" target="_blank">
-                    contact us
-                  </a>
-                  .
-                </p>
-              </div>
-            </AUpageAlert>
-          )}
-          {this.props[this.props.model].openTo === 'selected' && (
-            <React.Fragment>
-              <SellerSelect
-                briefId={this.props[this.props.model].id}
-                label="Seller name"
-                showSelected={false}
-                showSearchButton={false}
-                categories={categories}
-                onSellerSelect={this.handleSellerSelect}
-                onSellerCategorySelect={this.handleSellerCategorySelect}
-                showCategorySelect={false}
-                notFoundMessage="Seller is not on the Digital Marketplace"
-                selectedCategory="labourHire"
-                showSellerCatalogueLink
-              />
-              <br />
-              <SelectedSellersControl
-                id="selected-sellers"
-                model={`${this.props.model}.sellers`}
-                onRemoveClick={sellerCode => this.removeSeller(sellerCode)}
-              />
-            </React.Fragment>
-          )}
-          <PanelCategorySelect
-            id="select-seller"
-            categories={categories}
-            onChange={e => this.handleSellerCategorySelect(e.target.value)}
-            selectedCategory={this.props[this.props.model].sellerCategory}
-            label="Category"
-            description="Please select the category that best suits your opportunity. This is for reporting purposes only and will not limit who can respond."
-            helpLabel="View category descriptions"
+          <RadioList
+            id="openTo"
+            label="Accept responses from:"
+            name="openTo"
+            model={`${this.props.model}.openTo`}
+            options={[
+              {
+                label: 'Any seller that provides ICT Labour Hire',
+                value: 'all'
+              },
+              {
+                label: 'Specific ICT Labour Hire sellers',
+                value: 'selected'
+              }
+            ]}
+            messages={{}}
           />
         </div>
+        {this.props[this.props.model].openTo === 'all' && (
+          <AUpageAlert as="warning" className={mainStyles.marginBottom3}>
+            <AUheading level="2" size="lg">
+              You are about to invite{' '}
+              {this.state.totalLabourHireSellers >= 1 ? this.state.totalLabourHireSellers : 'all'} seller
+              {this.state.totalLabourHireSellers === 1 ? '' : 's'}.
+            </AUheading>
+            <div className={mainStyles.marginTop1}>
+              <p>
+                You will need to reply to all seller questions, evaluate all quotes and debrief all unsuccessful
+                sellers (where requested).
+              </p>
+              <p>
+                You should only invite all sellers if there is a business need for this approach. If you have
+                questions, please{' '}
+                <a href="/contact-us" rel="noopener noreferrer" target="_blank">
+                  contact us
+                </a>
+                .
+              </p>
+            </div>
+          </AUpageAlert>
+        )}
+        {this.props[this.props.model].openTo === 'selected' && (
+          <React.Fragment>
+            <SellerSelect
+              briefId={this.props[this.props.model].id}
+              label="Seller name"
+              showSelected={false}
+              showSearchButton={false}
+              categories={categories}
+              onSellerSelect={this.handleSellerSelect}
+              onSellerCategorySelect={this.handleSellerCategorySelect}
+              showCategorySelect={false}
+              notFoundMessage="Seller is not on the Digital Marketplace"
+              selectedCategory="labourHire"
+              showSellerCatalogueLink
+            />
+            <br />
+            <SelectedSellersControl
+              id="selected-sellers"
+              model={`${this.props.model}.sellers`}
+              onRemoveClick={sellerCode => this.removeSeller(sellerCode)}
+            />
+          </React.Fragment>
+        )}
+        <PanelCategorySelect
+          id="select-seller"
+          categories={categories}
+          onChange={e => this.handleSellerCategorySelect(e.target.value)}
+          selectedCategory={this.props[this.props.model].sellerCategory}
+          label="Category"
+          description="Please select the category that best suits your opportunity. This is for reporting purposes only and will not limit who can respond."
+          helpLabel="View category descriptions"
+        />
         {this.props.formButtons}
       </Form>
     )

--- a/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
+++ b/apps/marketplace/components/BuyerSpecialist/BuyerSpecialistSelectStage.js
@@ -13,10 +13,10 @@ import { countLabourHireSellers } from 'marketplace/actions/supplierActions'
 
 import mainStyles from '../../main.scss'
 
-const requiredCategory = v => v.sellerCategory
-const requiredChoice = v => !v.sellerCategory || v.openTo
+const requiredChoice = v => v.openTo
 const atLeastOneSeller = v =>
   !v.openTo || v.openTo === 'all' || (v.openTo === 'selected' && v.sellers && Object.keys(v.sellers).length > 0)
+const requiredCategory = v => v.sellerCategory
 
 export const done = v => requiredCategory(v) && requiredChoice(v) && atLeastOneSeller(v)
 
@@ -58,8 +58,8 @@ export class BuyerSpecialistSelectStage extends Component {
   handleSellerCategorySelect(category) {
     if (category !== this.props[this.props.model].sellerCategory) {
       this.props.updateSelectedSellerCategory(category)
-      this.props.resetOpenTo()
-      this.props.resetSelectedSellers()
+      //this.props.resetOpenTo()
+      //this.props.resetSelectedSellers()
     }
   }
 
@@ -89,9 +89,9 @@ export class BuyerSpecialistSelectStage extends Component {
         model={this.props.model}
         validators={{
           '': {
-            requiredCategory,
             requiredChoice,
-            atLeastOneSeller
+            atLeastOneSeller,
+            requiredCategory
           }
         }}
         onSubmit={this.props.onSubmit}
@@ -109,83 +109,83 @@ export class BuyerSpecialistSelectStage extends Component {
             atLeastOneSeller: 'You must add at least one seller'
           }}
         />
-        <PanelCategorySelect
-          id="select-seller"
-          categories={categories}
-          onChange={e => this.handleSellerCategorySelect(e.target.value)}
-          selectedCategory={this.props[this.props.model].sellerCategory}
-          label="Category"
-        />
-        {this.props[this.props.model].sellerCategory && (
+        <div>
           <div>
-            <div>
-              <RadioList
-                id="openTo"
-                label="Accept responses from:"
-                name="openTo"
-                model={`${this.props.model}.openTo`}
-                options={[
-                  {
-                    label: 'Any seller that provides ICT Labour Hire',
-                    value: 'all'
-                  },
-                  {
-                    label: 'Specific ICT Labour Hire sellers',
-                    value: 'selected'
-                  }
-                ]}
-                messages={{}}
-                onChange={() => this.props.resetSelectedSellers()}
-              />
-            </div>
-            {this.props[this.props.model].openTo === 'all' && (
-              <AUpageAlert as="warning">
-                <AUheading level="2" size="lg">
-                  You are about to invite{' '}
-                  {this.state.totalLabourHireSellers >= 1 ? this.state.totalLabourHireSellers : 'all'} seller
-                  {this.state.totalLabourHireSellers === 1 ? '' : 's'}.
-                </AUheading>
-                <div className={mainStyles.marginTop1}>
-                  <p>
-                    You will need to reply to all seller questions, evaluate all quotes and debrief all unsuccessful
-                    sellers (where requested).
-                  </p>
-                  <p>
-                    You should only invite all sellers if there is a business need for this approach. If you have
-                    questions, please{' '}
-                    <a href="/contact-us" rel="noopener noreferrer" target="_blank">
-                      contact us
-                    </a>
-                    .
-                  </p>
-                </div>
-              </AUpageAlert>
-            )}
-            {this.props[this.props.model].openTo === 'selected' && (
-              <React.Fragment>
-                <SellerSelect
-                  briefId={this.props[this.props.model].id}
-                  label="Seller name"
-                  showSelected={false}
-                  showSearchButton={false}
-                  categories={categories}
-                  onSellerSelect={this.handleSellerSelect}
-                  onSellerCategorySelect={this.handleSellerCategorySelect}
-                  showCategorySelect={false}
-                  notFoundMessage="Seller is not on the Digital Marketplace"
-                  selectedCategory="labourHire"
-                  showSellerCatalogueLink
-                />
-                <br />
-                <SelectedSellersControl
-                  id="selected-sellers"
-                  model={`${this.props.model}.sellers`}
-                  onRemoveClick={sellerCode => this.removeSeller(sellerCode)}
-                />
-              </React.Fragment>
-            )}
+            <RadioList
+              id="openTo"
+              label="Accept responses from:"
+              name="openTo"
+              model={`${this.props.model}.openTo`}
+              options={[
+                {
+                  label: 'Any seller that provides ICT Labour Hire',
+                  value: 'all'
+                },
+                {
+                  label: 'Specific ICT Labour Hire sellers',
+                  value: 'selected'
+                }
+              ]}
+              messages={{}}
+              onChange={() => this.props.resetSelectedSellers()}
+            />
           </div>
-        )}
+          {this.props[this.props.model].openTo === 'all' && (
+            <AUpageAlert as="warning">
+              <AUheading level="2" size="lg">
+                You are about to invite{' '}
+                {this.state.totalLabourHireSellers >= 1 ? this.state.totalLabourHireSellers : 'all'} seller
+                {this.state.totalLabourHireSellers === 1 ? '' : 's'}.
+              </AUheading>
+              <div className={mainStyles.marginTop1}>
+                <p>
+                  You will need to reply to all seller questions, evaluate all quotes and debrief all unsuccessful
+                  sellers (where requested).
+                </p>
+                <p>
+                  You should only invite all sellers if there is a business need for this approach. If you have
+                  questions, please{' '}
+                  <a href="/contact-us" rel="noopener noreferrer" target="_blank">
+                    contact us
+                  </a>
+                  .
+                </p>
+              </div>
+            </AUpageAlert>
+          )}
+          {this.props[this.props.model].openTo === 'selected' && (
+            <React.Fragment>
+              <SellerSelect
+                briefId={this.props[this.props.model].id}
+                label="Seller name"
+                showSelected={false}
+                showSearchButton={false}
+                categories={categories}
+                onSellerSelect={this.handleSellerSelect}
+                onSellerCategorySelect={this.handleSellerCategorySelect}
+                showCategorySelect={false}
+                notFoundMessage="Seller is not on the Digital Marketplace"
+                selectedCategory="labourHire"
+                showSellerCatalogueLink
+              />
+              <br />
+              <SelectedSellersControl
+                id="selected-sellers"
+                model={`${this.props.model}.sellers`}
+                onRemoveClick={sellerCode => this.removeSeller(sellerCode)}
+              />
+            </React.Fragment>
+          )}
+          <PanelCategorySelect
+            id="select-seller"
+            categories={categories}
+            onChange={e => this.handleSellerCategorySelect(e.target.value)}
+            selectedCategory={this.props[this.props.model].sellerCategory}
+            label="Category"
+            description="Please select the category that best suits your opportunity. This is for reporting purposes only and will not limit who can respond."
+            helpLabel="View category descriptions"
+          />
+        </div>
         {this.props.formButtons}
       </Form>
     )

--- a/apps/marketplace/components/SellerSelect/SellerSelect.js
+++ b/apps/marketplace/components/SellerSelect/SellerSelect.js
@@ -14,8 +14,11 @@ const PanelCategorySelectView = props => (
       rel="noopener noreferrer"
       target="_blank"
     >
-      What you can buy in each category
+      {props.helpLabel ? props.helpLabel : 'What you can buy in each category'}
     </a>
+    {props.description &&
+      <span>{props.description}</span>
+    }
     <AUselect
       block
       id={`${props.id}-category-select`}
@@ -34,6 +37,8 @@ export const PanelCategorySelect = props => (
       onChange={props.onChange}
       selectedCategory={props.selectedCategory}
       label={props.label}
+      description={props.description}
+      helpLabel={props.helpLabel}
     />
   </div>
 )
@@ -49,7 +54,9 @@ PanelCategorySelect.propTypes = {
   categories: PropTypes.array.isRequired,
   onChange: PropTypes.func,
   selectedCategory: PropTypes.string,
-  label: PropTypes.string
+  label: PropTypes.string,
+  description: PropTypes.string,
+  helpLabel: PropTypes.string
 }
 
 const SellerSelectView = props => (

--- a/apps/marketplace/components/SellerSelect/SellerSelect.js
+++ b/apps/marketplace/components/SellerSelect/SellerSelect.js
@@ -14,7 +14,7 @@ const PanelCategorySelectView = props => (
       rel="noopener noreferrer"
       target="_blank"
     >
-      {props.helpLabel ? props.helpLabel : 'What you can buy in each category'}
+      {props.helpLabel}
     </a>
     {props.description &&
       <span>{props.description}</span>
@@ -46,7 +46,9 @@ export const PanelCategorySelect = props => (
 PanelCategorySelect.defaultProps = {
   onChange: () => {},
   selectedCategory: '',
-  label: 'Panel category'
+  label: 'Panel category',
+  helpLabel: 'What you can buy in each category',
+  description: ''
 }
 
 PanelCategorySelect.propTypes = {

--- a/apps/marketplace/components/SellerSelect/SellerSelect.js
+++ b/apps/marketplace/components/SellerSelect/SellerSelect.js
@@ -16,9 +16,7 @@ const PanelCategorySelectView = props => (
     >
       {props.helpLabel}
     </a>
-    {props.description &&
-      <span>{props.description}</span>
-    }
+    {props.description && <span>{props.description}</span>}
     <AUselect
       block
       id={`${props.id}-category-select`}


### PR DESCRIPTION
This pull request reorders components on the "Who Can Respond" stage so the radio list appeared before the category dropdown.
The changes also include:

- extra props for PanelCategorySelect component (description - text displayed underneath field label; helpLabel - text displayed in hyperlink for categories & rates page) 

![Screenshot](https://user-images.githubusercontent.com/98563383/152709870-011679f4-69e5-4cdf-b5b2-365af724fbb4.png)
