### PR TITLE
Page alerts hm 4452 Page alerts for changes to ICT labour hire

### DIFF
--- a/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
+++ b/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import AUaccordion from '@gov.au/accordion/lib/js/react.js'
+import AUpageAlert from '@gov.au/page-alerts/lib/js/react.js'
 import { rootPath } from 'marketplace/routes'
 import { hasPermission } from 'marketplace/components/helpers'
 import PageHeader from 'marketplace/components/PageHeader/PageHeader'
@@ -30,6 +31,16 @@ class BuyerDashboardHeader extends Component {
     const { briefCounts, isPartOfTeam, isTeamLead, organisation, teams } = this.props
     return (
       <React.Fragment>
+        <AUpageAlert as="warning">
+          Updates to the Digital Marketplace
+          <br />
+          We will soon make some updates to the Digital Marketplace including the creation of the new ICT Labour Hire
+          category, and the renaming of &quot;Specialist&quot; and &quot;Outcome&quot; opportunities. For more
+          information on how this affects you,{' '}
+          <a href="https://mailchi.mp/ae94e5dd228d/new-digital-marketplace-category-platforms-integration-988037">
+            click here.
+          </a>
+        </AUpageAlert>
         <PageHeader
           organisation={organisation}
           title="Dashboard"

--- a/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
+++ b/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
@@ -32,8 +32,7 @@ class BuyerDashboardHeader extends Component {
     return (
       <React.Fragment>
         <AUpageAlert as="warning">
-          Updates to the Digital Marketplace
-          <br />
+          <h3>Updates to the Digital Marketplace</h3>
           We will soon make some updates to the Digital Marketplace including the creation of the new ICT Labour Hire
           category, and the renaming of &quot;Specialist&quot; and &quot;Outcome&quot; opportunities. For more
           information on how this affects you,{' '}
@@ -41,6 +40,7 @@ class BuyerDashboardHeader extends Component {
             click here.
           </a>
         </AUpageAlert>
+        <br />
         <PageHeader
           organisation={organisation}
           title="Dashboard"

--- a/apps/marketplace/pages/SellerDashboardPage.js
+++ b/apps/marketplace/pages/SellerDashboardPage.js
@@ -82,8 +82,7 @@ class SellerDashboardPage extends Component {
       <BrowserRouter basename={`${rootPath}/seller-dashboard`}>
         <div>
           <AUpageAlert as="warning">
-            Updates to the Digital Marketplace
-            <br />
+            <h3>Updates to the Digital Marketplace</h3>
             We will soon make some updates to the Digital Marketplace including the creation of the new ICT Labour Hire
             category, and the renaming of &quot;Specialist&quot; and &quot;Outcome&quot; opportunities. For more
             information on how this affects you,{' '}
@@ -91,6 +90,7 @@ class SellerDashboardPage extends Component {
               click here.
             </a>
           </AUpageAlert>
+          <br />
           <div className="row">
             <div className="col-xs-12">{supplier.name}</div>
           </div>

--- a/apps/marketplace/pages/SellerDashboardPage.js
+++ b/apps/marketplace/pages/SellerDashboardPage.js
@@ -81,6 +81,16 @@ class SellerDashboardPage extends Component {
     return (
       <BrowserRouter basename={`${rootPath}/seller-dashboard`}>
         <div>
+          <AUpageAlert as="warning">
+            Updates to the Digital Marketplace
+            <br />
+            We will soon make some updates to the Digital Marketplace including the creation of the new ICT Labour Hire
+            category, and the renaming of &quot;Specialist&quot; and &quot;Outcome&quot; opportunities. For more
+            information on how this affects you,{' '}
+            <a href="https://mailchi.mp/3d8298eb0100/new-digital-marketplace-category-platforms-integration-988033?e=[UNIQID]">
+              click here.
+            </a>
+          </AUpageAlert>
           <div className="row">
             <div className="col-xs-12">{supplier.name}</div>
           </div>


### PR DESCRIPTION
page alerts for changes to ICT labour hire/category 

buyer dashboard and seller dashboard - top of page

“click here” links as below:

Seller link -> [New Digital Marketplace Category - Labour Hire](https://mailchi.mp/3d8298eb0100/new-digital-marketplace-category-platforms-integration-988033?e=%5BUNIQID%5D) 

Buyer link -> [New Digital Marketplace Category - Labour Hire](https://mailchi.mp/ae94e5dd228d/new-digital-marketplace-category-platforms-integration-988037) 

BANNER CONTENT
Prior to launch - 9am 17/02
"Updates to the Digital Marketplace"
"We will soon make some updates to the Digital Marketplace including the creation of the new ICT Labour Hire category, and the renaming of "Specialist" and "Outcome" opportunities. For more information on how this affects you, click here." (Link different depending on if it is on Buyer or seller dashboard)

**To be deployed later in another commit in another release -->** ON/after launch - 6:30pm 17/2
"Updates to the Digital Marketplace"
"We have recently made a few changes to the Digital Marketplace including the creation of the new ICT Labour Hire category, and the renaming of "Specialist" and "Outcome" opportunities. For more information on how this affects you, click here." (Link different depending on if it is on Buyer or seller dashboard)