### PR TITLE
HM-4592: Content changes for insights and download work order pages

### DIFF
--- a/apps/marketplace/components/Brief/BriefDownloadWorkOrder.js
+++ b/apps/marketplace/components/Brief/BriefDownloadWorkOrder.js
@@ -42,12 +42,12 @@ export class BriefDownloadWorkOrder extends Component {
         {brief.lotSlug === 'specialist' && (
           <React.Fragment>
             <p>
-              We recommend you use the <b>specialist work order template</b> for this opportunity. This work order is
-              suitable for hiring specialists.
+              We recommend you use the <b>ICT Labour Hire work order template</b> for this opportunity. This work order
+              is suitable for hiring specialists.
             </p>
             <p>
               <AUbutton link="/api/2/r/specialist-work-order.docx" rel="noopener noreferrer" target="_blank">
-                Download specialist work order
+                Download ICT Labour Hire work order
               </AUbutton>
             </p>
           </React.Fragment>

--- a/apps/marketplace/components/Insights/DailyRates.js
+++ b/apps/marketplace/components/Insights/DailyRates.js
@@ -88,7 +88,7 @@ export class DailyRates extends Component {
         <div className={`row ${styles.marginBottom1}`}>
           <div className="col-xs-12 col-md-12">
             <AUheading size="lg" level="2">
-              Range of daily rates submitted for specialist roles (includes GST)
+              Range of daily rates submitted for ICT Labour Hire roles (includes GST)
             </AUheading>
           </div>
         </div>

--- a/apps/marketplace/components/Insights/ResponsesPerOpportunity.js
+++ b/apps/marketplace/components/Insights/ResponsesPerOpportunity.js
@@ -27,7 +27,7 @@ export class ResponsesPerOpportunity extends Component {
             backgroundColor: '#0985D1'
           },
           {
-            label: 'Specialist',
+            label: 'ICT Labour Hire',
             data: counts.filter(c => c.briefType === 'Specialist').map(a => a.count),
             backgroundColor: '#660033'
           }

--- a/apps/marketplace/components/Insights/SpecialistPercent.js
+++ b/apps/marketplace/components/Insights/SpecialistPercent.js
@@ -54,7 +54,7 @@ export class SpecialistPercent extends Component {
         </div>
         <div className="col-xs-12 col-md-6">
           {numeral(this.props.insightData.briefData.specialistBriefPercentage).format('(0%)')} of all opportunities are
-          for digital specialists since 29 August 2016
+          for ICT Labour Hire since 29 August 2016
         </div>
       </div>
     )


### PR DESCRIPTION
This pull request replaces references to `specialist` with `ICT Labour Hire` on the insights and download work order pages.