### PR TITLE
HM-2867: Fix validation error message by removing dollar symbol

### DIFF
--- a/apps/marketplace/components/SellerAssessment/SellerAssessmentCriteriaStage.js
+++ b/apps/marketplace/components/SellerAssessment/SellerAssessmentCriteriaStage.js
@@ -46,7 +46,7 @@ const getMaximumMessage = (criteriaAllowed, essentialCriteria) => {
     )
   }
 
-  return <span>You cannot submit evidence for more than ${criteriaAllowed} criteria.</span>
+  return <span>You cannot submit evidence for more than {criteriaAllowed} criteria.</span>
 }
 
 const minimumCriteriaMet = (v, d) =>


### PR DESCRIPTION
This pull request removes an unnecessary dollar symbol from the validation error message when the number of criteria selected for a seller assessment has exceed the limit.

**Preview:**

![Screenshot](https://user-images.githubusercontent.com/98563383/158475390-4b1bacb7-174b-47c9-8718-d0a4ba4dd504.png)