### PR TITLE
HM-4805: Remove page alerts for ICT Labour Hire changes

### DIFF
--- a/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
+++ b/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
@@ -2,12 +2,10 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import AUaccordion from '@gov.au/accordion/lib/js/react.js'
-import AUpageAlert from '@gov.au/page-alerts/lib/js/react.js'
 import { rootPath } from 'marketplace/routes'
 import { hasPermission } from 'marketplace/components/helpers'
 import PageHeader from 'marketplace/components/PageHeader/PageHeader'
 import PageNavigation from 'marketplace/components/PageNavigation/PageNavigation'
-import mainStyles from 'marketplace/main.scss'
 import styles from './BuyerDashboard.scss'
 
 class BuyerDashboardHeader extends Component {

--- a/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
+++ b/apps/marketplace/components/BuyerDashboard/BuyerDashboardHeader.js
@@ -32,20 +32,6 @@ class BuyerDashboardHeader extends Component {
     const { briefCounts, isPartOfTeam, isTeamLead, organisation, teams } = this.props
     return (
       <React.Fragment>
-        <AUpageAlert as="warning" className={`${mainStyles.marginBottom3}`}>
-          <h3>Updates to the Digital Marketplace</h3>
-          <br />
-          We have recently made a few changes to the Digital Marketplace including the creation of the new ICT Labour
-          Hire Hire category, and the renaming of &quot;Specialist&quot; and &quot;Outcome&quot; opportunities. For more
-          information on how this affects you,{' '}
-          <a
-            href="https://mailchi.mp/ae94e5dd228d/new-digital-marketplace-category-platforms-integration-988037"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            click here.
-          </a>
-        </AUpageAlert>
         <PageHeader
           organisation={organisation}
           title="Dashboard"

--- a/apps/marketplace/pages/SellerDashboardPage.js
+++ b/apps/marketplace/pages/SellerDashboardPage.js
@@ -12,7 +12,6 @@ import { loadSellerDashboard, removeUser } from 'marketplace/actions/sellerDashb
 import LoadingIndicatorFullPage from 'shared/LoadingIndicatorFullPage/LoadingIndicatorFullPage'
 import { ErrorBoxComponent } from 'shared/form/ErrorBox'
 import { rootPath } from 'marketplace/routes'
-import mainStyles from 'marketplace/main.scss'
 import styles from '../main.scss'
 
 class SellerDashboardPage extends Component {

--- a/apps/marketplace/pages/SellerDashboardPage.js
+++ b/apps/marketplace/pages/SellerDashboardPage.js
@@ -82,20 +82,6 @@ class SellerDashboardPage extends Component {
     return (
       <BrowserRouter basename={`${rootPath}/seller-dashboard`}>
         <div>
-          <AUpageAlert as="warning" className={`${mainStyles.marginBottom3}`}>
-            <h3>Updates to the Digital Marketplace</h3>
-            <br />
-            We have recently made a few changes to the Digital Marketplace including the creation of the new ICT Labour
-            Hire category, and the renaming of &quot;Specialist&quot; and &quot;Outcome&quot; opportunities. For more
-            information on how this affects you,{' '}
-            <a
-              href="https://mailchi.mp/3d8298eb0100/new-digital-marketplace-category-platforms-integration-988033?e=[UNIQID]"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              click here.
-            </a>
-          </AUpageAlert>
           <div className="row">
             <div className="col-xs-12">{supplier.name}</div>
           </div>


### PR DESCRIPTION
This pull request removes the page alerts on the buyer and seller dashboards which announced the ICT Labour Hire release.